### PR TITLE
Overhaul README — conversion-focused rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,40 @@
-# 49Agents
+<p align="center">
+  <img alt="49Agents" src="https://github.com/user-attachments/assets/93d237b6-e1ec-40ea-aa30-6feb72ca6599" height="120" />
+</p>
 
-Your terminals on an infinite canvas. Pan, zoom, and arrange real terminal panes in a browser — powered by tmux.
+<h1 align="center">49Agents</h1>
 
-**[49agents.com](https://49agents.com)**
+<p align="center">The first 2D agentic IDE. Open source.</p>
 
-<img width="2559" height="1013" alt="49Agents — infinite canvas terminal workspace" src="https://github.com/user-attachments/assets/33238bd9-589c-438b-85a9-1c3ee780eca3" />
+<p align="center"><strong>All agents. All terminals. All projects. All machines. One unified space.</strong></p>
 
-## Why 49Agents?
+<p align="center">
+  <a href="https://github.com/49Agents/49Agents/stargazers"><img src="https://img.shields.io/github/stars/49Agents/49Agents?style=flat" alt="GitHub Stars" /></a>
+  <a href="https://discord.gg/rkUbxYvGj"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://twitter.com/49agents"><img src="https://img.shields.io/twitter/follow/49agents" alt="Twitter Follow" /></a>
+</p>
 
-- **Infinite canvas** — arrange terminals, files, notes, and web pages in a spatial workspace. Pan and zoom with trackpad or mouse. No tabs, no splits — just place things where they make sense.
-- **Real terminals** — not a web shell emulator. Every pane runs in tmux via ttyd, with full ANSI support, scrollback, and your shell config.
-- **Multi-machine** — connect agents from multiple machines to one dashboard. SSH into your homelab from a phone, or monitor a fleet of servers from a single browser tab.
-- **File editor** — open files in Monaco (the VS Code editor engine) directly alongside your terminals.
-- **Notes** — Markdown notes with live preview, pinned to the canvas for reference.
-- **Git graph** — visual commit history with branch lanes, rendered as SVG.
-- **Beads** — lightweight issue tracking built in. Create, tag, and filter issues without leaving the workspace.
-- **Folder browser** — tree view with git status indicators, inline rename, and click-to-open.
-- **Web embeds** — pin any URL as an iframe pane (docs, dashboards, PRs).
-- **Claude Code awareness** — detects running Claude sessions, shows working/idle/permission state, and notifies you with sounds when Claude needs your attention.
-- **Keyboard-first** — Tab chords for pane switching, WASD move mode, shortcut numbers (1-9), broadcast input to multiple terminals.
-- **Access from anywhere** — open the workspace from a laptop, tablet, or phone. Works over Tailscale, LAN, or the hosted version (coming soon).
-- **Self-hosted** — run the whole stack on your own hardware. No data leaves your network.
+<img width="100%" alt="Before — terminal clutter" src="https://github.com/user-attachments/assets/b06c8fe8-d1bf-432a-b935-bbf8376bd7ff" />
 
-## How It Works
+<img width="100%" alt="After — 49Agents" src="https://github.com/user-attachments/assets/878b3926-e017-4ccc-9c54-315b647fd417" />
 
-```
-Your Machine                        Cloud Server (relay)
-┌──────────────┐                   ┌──────────────────┐
-│  49-agent    │ ──── WSS ───────► │  WebSocket relay  │
-│  (tmux+ttyd) │                   │  + web app        │
-└──────────────┘                   │  + SQLite         │
-                                   └────────┬─────────┘
-                                            │
-                                   ◄── WSS ─┘
-                                   │
-                             ┌─────┴──────┐
-                             │  Browser    │
-                             │  (xterm.js) │
-                             └────────────┘
-```
+---
 
-The **agent** runs on your machine and manages tmux sessions via ttyd. The **cloud server** is a WebSocket relay that routes terminal I/O between the agent and your browser. No terminal data is stored on the server.
+| Before | With 49Agents |
+|--------|--------------|
+| 14 terminal tabs | One zoomable canvas |
+| SSH into each machine | All machines, zero SSH |
+| Alt-tab to check Claude | Claude status on every pane |
+| Can't work from phone | Any device, anywhere |
+| Terminal-only, no files | Monaco editor on the canvas |
+| 🤷 | Git graph |
+| 🤷 | Interactive issue tables ([Beads](https://github.com/steveyegge/beads)) |
+| 🤷 | Permission notifications |
+| 🤷 | Markdown notes |
+
+---
 
 ## Quick Start
-
-**Prerequisites:** Node.js 18+, tmux, [ttyd](https://github.com/tsl0922/ttyd#installation)
 
 ```bash
 git clone https://github.com/49Agents/49Agents.git
@@ -53,161 +43,88 @@ cd 49Agents
 ./49ctl start    # start cloud server + agent
 ```
 
-Open `http://localhost:1071` in your browser. No account, no login, no token needed for local use.
+Open `http://localhost:1071`. No account, no login, no token.
 
-## Managing Services
+Don't want to self-host? **[49agents.com](https://49agents.com)**
 
-```bash
-./49ctl start          # Start cloud + agent (based on setup config)
-./49ctl stop           # Stop everything cleanly
-./49ctl restart        # Stop + start
-./49ctl status         # Show what's running, PIDs, ports
-./49ctl logs           # Tail both cloud and agent logs
-./49ctl logs cloud     # Tail cloud logs only
-./49ctl logs agent     # Tail agent logs only
-./49ctl build          # Rebuild client assets + agent tarball
+<img width="100%" alt="49Agents tutorial" src="https://github.com/user-attachments/assets/418d37c3-d52e-4de7-9726-28844527eca2" />
 
-./49ctl cloud-start    # Start only the cloud server
-./49ctl cloud-stop     # Stop only the cloud server
-./49ctl agent-start    # Start only the agent
-./49ctl agent-stop     # Stop only the agent
-```
+---
 
-You can also use `./start.sh` for the original interactive setup-and-run experience.
+## Features
 
-## Single Machine Setup
+### Canvas and Workspace
 
-Run `./49ctl setup`, choose **Single machine**, enter a port (default: `1071`). Then `./49ctl start`.
+- [x] **Infinite canvas** — no tabs, no splits. Place panes anywhere on a zoomable surface
+- [x] **Drag, resize, arrange** — your workspace grows with your thinking, not your monitor
+- [x] **Zoom levels** — zoom out for the big picture, zoom in to focus
+- [x] **Persistent layout** — everything stays where you put it
 
-## Multi-Machine Setup
+### Terminals
 
-Run the cloud server on one machine and the agent on another (useful for accessing terminals from a laptop, tablet, or phone via a private network like [Tailscale](https://tailscale.com)).
+- [x] **Real tmux sessions** via ttyd — full ANSI color, scrollback, your shell config
+- [x] **Broadcast input** — type once, send keystrokes to multiple terminals simultaneously
 
-Run `./49ctl setup`, choose **Multi machine**, then:
+### Multi-Machine
 
-- **Cloud only** — runs just the relay server. Choose a port. Open `http://<this-machine-ip>:<port>` from any device on your network.
-- **Agent only** — runs just the agent. Enter the WebSocket URL of your cloud server (e.g. `ws://192.168.1.10:1071`).
-- **Both** — runs cloud and agent on this machine, useful as the "server" node in a multi-machine setup.
+- [x] **Zero SSH** — connect agents from any machine to one canvas
+- [x] **HUD overlay** — live CPU, RAM, and Claude API usage across all connected machines
 
-You can run agents on multiple machines all pointing at the same cloud server and switch between them from one browser tab.
+### Access
 
-## No Auth by Default
+- [x] **Any device** — laptop, tablet, phone. Same workspace, same layout
+- [x] **Tailscale / LAN / hosted relay** — works however you connect
+- [x] **Fully self-hosted** — the entire stack runs on your hardware
+- [x] **No data stored server-side** — terminal I/O is relayed, never persisted
 
-When no OAuth credentials are configured, the server runs in local mode — no login screen, no accounts. Anyone who can reach the server gets in. This is fine for Tailscale or a local network.
+### Keyboard-First
 
-**To add authentication** for multi-user setups, register a [GitHub OAuth App](https://github.com/settings/applications/new) or Google OAuth credentials and set the env vars:
+- [x] **Tab chords** for pane switching
+- [x] **WASD move mode** for spatial navigation
+- [x] **Shortcut numbers** (1–9) for instant pane focus
+- [x] **Broadcast mode** for multi-terminal input
 
-```bash
-GITHUB_CLIENT_ID=...
-GITHUB_CLIENT_SECRET=...
-```
+---
 
-When OAuth is configured, the server requires login. When it's not, it's open — keep it behind a private network or firewall.
-
-## Agent CLI
-
-The agent binary lives at `agent/bin/49-agent.js` (or `~/.49agents/agent/bin/49-agent.js` if installed remotely).
+## Architecture
 
 ```
-49-agent start               Connect to relay (foreground, logs to stdout)
-49-agent start --daemon      Connect to relay (background, writes PID file)
-49-agent stop                Stop the background agent process
-49-agent status              Check if the agent is running and show PID
-49-agent config              Set a custom cloud server URL for private networks
-49-agent login <token>       Store an auth token (used during remote pairing)
-49-agent install-service     Print instructions to install as a system service
+┌──────────────┐    WSS    ┌──────────────┐    WSS    ┌──────────────┐
+│  🖥️ PC       │ ────────► │  ☁️ Relay     │ ◄──────── │  📱 Browser   │
+│  49-agent    │           │              │           │              │
+└──────────────┘           └──────────────┘           └──────────────┘
+                           Self-host or use
+                            49agents.com
 ```
 
-### Running the Agent as a System Service
-
-By default, the agent runs as a foreground process (via `./49ctl start` or `49-agent start`). If you want it to **auto-start on boot** and run permanently in the background, you can install it as a system service:
-
-```bash
-49-agent install-service
-```
-
-This prints copy-paste instructions for your OS (it does **not** install anything automatically):
-
-- **macOS (launchd)** — creates a plist at `~/Library/LaunchAgents/com.49agents.agent.plist`. The agent starts on login and restarts if it crashes.
-- **Linux (systemd)** — creates a user service at `~/.config/systemd/user/49-agent.service`. Same behavior: starts on login, auto-restarts on failure.
-
-This is optional. For local development, `./49ctl start` and `./49ctl stop` are all you need.
-
-## Session & State Management
-
-49Agents stores persistent state in several places. Use `./49ctl session` to see everything at a glance.
-
-| What | Where | Purpose |
-|------|-------|---------|
-| Agent auth token | `~/.49agents/agent.json` | Authenticates the agent with the cloud server. Persists across restarts so you don't re-pair each time. |
-| Terminal tracking | `~/.49agents/terminals.json` | Agent's record of which tmux sessions it manages. Panes reappear in the browser after an agent restart. |
-| Cloud database | `cloud/data/tc.db` | SQLite — stores users, agent registrations, pane layouts, notes, and preferences. |
-| Browser state | `localStorage` | Tutorial completion, UI drafts. Cleared by browser. |
-
-```bash
-./49ctl session            # Show all persistent state
-./49ctl reset-agent        # Delete auth token (forces re-pairing)
-./49ctl reset-terminals    # Clear terminal tracking (agent re-discovers on start)
-./49ctl reset-db           # Delete cloud database (users, layouts, notes)
-./49ctl reset-all          # Full state wipe (fresh start)
-./49ctl clear-logs         # Truncate log files
-```
-
-## Configuration
-
-The cloud server is configured via environment variables:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | `1071` | Cloud server port |
-| `HOST` | `0.0.0.0` | Bind address |
-| `JWT_SECRET` | dev default | Secret for signing user JWTs |
-| `AGENT_JWT_SECRET` | dev default | Secret for signing agent JWTs |
-| `GITHUB_CLIENT_ID` | _(none)_ | GitHub OAuth — enables login |
-| `GITHUB_CLIENT_SECRET` | _(none)_ | GitHub OAuth secret |
-| `GOOGLE_CLIENT_ID` | _(none)_ | Google OAuth — enables login |
-| `GOOGLE_CLIENT_SECRET` | _(none)_ | Google OAuth secret |
-| `DATABASE_PATH` | `./data/tc.db` | SQLite database path |
-
-The agent reads these env vars:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `TC_CLOUD_URL` | `ws://localhost:1071` | WebSocket URL of the cloud relay |
-| `TC_CONFIG_DIR` | `~/.49agents` | Agent config and state directory |
-
-## Project Structure
+<details>
+<summary>Multi-machine setup</summary>
 
 ```
-agent/                  # Agent daemon (runs on your machine)
-├── bin/49-agent.js     # CLI entry point
-├── src/                # Core: relay client, terminal manager, auth
-└── services/           # tmux, file browsing, git, metrics
+┌──────────────┐                                         ┌──────────────┐
+│  🖥️ MacBook   │ ─── WSS ───┐                       ┌─── │  📱 Phone     │
+│  49-agent    │             │                       │    │  Browser     │
+└──────────────┘             │                       │    └──────────────┘
+                             │   ┌──────────────┐    │
+┌──────────────┐             ├──►│  ☁️ Relay     │◄───┤    ┌──────────────┐
+│  🖥️ PC        │ ─── WSS ───┤   │              │    ├─── │  💻 Laptop    │
+│  49-agent    │             │   │  Self-host   │    │    │  Browser     │
+└──────────────┘             │   │  or use      │    │    └──────────────┘
+                             │   │ 49agents.com │    │
+┌──────────────┐             │   └──────────────┘    │    ┌──────────────┐
+│  ☁️ Azure VM  │ ─── WSS ───┘                       └─── │  📱 Tablet    │
+│  49-agent    │                                          │  Browser     │
+└──────────────┘                                          └──────────────┘
 
-cloud/                  # Cloud server (relay + web app)
-├── src/                # Server: WebSocket relay, auth, API routes, DB
-├── src-client/         # Frontend source (vanilla JS, modular)
-│   ├── app.js          # Main application
-│   └── modules/        # Extracted modules (sounds, utils, constants,
-│                       #   minimap, notifications, git-graph, pane renderers)
-├── public/             # Static assets (HTML, CSS, xterm.js)
-└── build.js            # Frontend build (esbuild + terser + obfuscator)
-
-49ctl                   # Process manager CLI
-start.sh                # Legacy setup script
+                  Each agent independently connects
+                   to the relay via WebSocket.
+                  No terminal data stored server-side.
 ```
 
-## System Requirements
+</details>
 
-- **Node.js** 18+
-- **tmux** — terminal multiplexer
-- **ttyd** — terminal over WebSocket ([install](https://github.com/tsl0922/ttyd#installation))
-- **git** _(optional)_ — for git graph features
-
-## Hosted Version
-
-We're building a hosted version at **[49agents.com](https://49agents.com)** — install the agent, pair it, and access your terminals from anywhere without running your own server. Join the waitlist on the site.
+---
 
 ## License
 
-[Business Source License 1.1](./LICENSE) — free for individuals and companies under $1M in revenue or funding. Converts to MIT on 2030-02-26.
+[BSL 1.1](./LICENSE) — free for individuals and small teams. Converts to MIT on 2030-02-26.


### PR DESCRIPTION
## Summary

- Replaces documentation-heavy README with a conversion-focused one
- Hero section: logo, "The first 2D agentic IDE. Open source.", before/after screenshots
- One-liner: "All agents. All terminals. All projects. All machines. One unified space."
- Badges: GitHub stars, Discord, X/Twitter
- Comparison table showing old workflow vs 49Agents (with 🤷 rows for features with no equivalent)
- Quick Start with tutorial GIF
- Categorized feature checkboxes (Canvas, Terminals, Multi-Machine, Access, Keyboard-First)
- Architecture diagrams: single machine + collapsible multi-machine with emojis
- Removed all ops documentation (service management, env vars, session state, project structure) — belongs in docs, not README

## What was removed

All operational documentation (service management CLI, env var tables, agent CLI reference, session/state management, project structure, auth setup, system requirements). This content should move to a docs site or wiki.

## Test plan

- [ ] Check README renders correctly on GitHub (especially ASCII diagrams with emojis)
- [ ] Verify all image URLs load
- [ ] Verify badge links work (stars, Discord, X)
- [ ] Confirm tutorial GIF plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)