### PR TITLE
feat: per-machine usage HUD with local timezone support

### DIFF
--- a/cloud/package-lock.json
+++ b/cloud/package-lock.json
@@ -2490,7 +2490,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -3936,6 +3936,25 @@ body.minimap-hidden #controls {
   padding: 8px 10px;
   display: block;
 }
+.git-graph-no-repo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 8px;
+  opacity: 0.5;
+}
+.git-graph-no-repo-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255,255,255,0.4);
+}
+.git-graph-no-repo-path {
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+  color: rgba(255,255,255,0.25);
+}
 
 /* SVG graph scroll container */
 .gg-scroll-container {

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -1971,6 +1971,32 @@ body.minimap-hidden #controls {
   opacity: 1;
 }
 
+/* Terminal context shortcut buttons (File / Git Graph / Folder from cwd) */
+.term-ctx-btn {
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: rgba(160, 180, 200, 0.35);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.15s;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.term-ctx-btn:hover {
+  background: rgba(100, 160, 220, 0.2);
+  color: rgba(160, 200, 240, 0.9);
+}
+
+.term-ctx-btn:active {
+  transform: scale(0.9);
+}
+
 /* Beads tag header button */
 .beads-tag-btn {
   width: 24px;

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -3725,35 +3725,35 @@ body.minimap-hidden #controls {
 }
 
 .usage-reset-icon {
-  width: 10px;
-  height: 10px;
+  width: 11px;
+  height: 11px;
   flex-shrink: 0;
-  opacity: 0.35;
+  opacity: 0.65;
 }
 
 .usage-reset-time {
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.55);
+  color: rgba(255, 255, 255, 0.85);
   flex: 1;
   font-family: "JetBrains Mono", "Fira Code", "SF Mono", monospace;
 }
 
 .usage-pct {
-  font-size: 10px;
-  font-weight: 600;
+  font-size: 11px;
+  font-weight: 700;
   font-family: "JetBrains Mono", "Fira Code", "SF Mono", monospace;
   flex-shrink: 0;
 }
 
-.usage-pct.low { color: rgba(16, 185, 129, 0.9); }
-.usage-pct.medium { color: rgba(245, 178, 11, 0.9); }
-.usage-pct.high { color: rgba(239, 68, 68, 0.95); }
+.usage-pct.low { color: #34d399; }
+.usage-pct.medium { color: #fbbf24; }
+.usage-pct.high { color: #f87171; }
 
 .usage-bar-track {
   width: 100%;
-  height: 5px;
-  background: rgba(255, 255, 255, 0.08);
+  height: 6px;
+  background: rgba(255, 255, 255, 0.12);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -3780,8 +3780,8 @@ body.minimap-hidden #controls {
 }
 
 .usage-period {
-  font-size: 8px;
-  color: rgba(255, 255, 255, 0.12);
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.4);
   font-family: "JetBrains Mono", "Fira Code", "SF Mono", monospace;
   margin-top: 2px;
 }

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -843,6 +843,16 @@ body.minimap-hidden #controls {
     inset 0 0 20px rgba(255, 255, 255, 0.05);
 }
 
+/* Depth-of-field: dim panes that overlap with the focused pane */
+.pane.depth-blur {
+  opacity: 0.55;
+  transition: opacity 0.3s ease;
+}
+
+.pane:not(.depth-blur) {
+  transition: opacity 0.3s ease;
+}
+
 /* Active dragging state */
 .pane.dragging {
   border-color: rgba(139, 92, 246, 0.8);

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -1559,8 +1559,16 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       const day = target.getDate();
       const hr = String(target.getHours()).padStart(2, '0');
       const min = String(target.getMinutes()).padStart(2, '0');
-      // 짧은 타임존 약어 (e.g. KST, PST, EST)
-      const tz = Intl.DateTimeFormat('en', { timeZoneName: 'short' }).formatToParts(target).find(p => p.type === 'timeZoneName')?.value || '';
+      // IANA 타임존 → 약어 매핑 (브라우저가 GMT+9 등을 반환하는 경우 대비)
+      const ianaZone = Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+      const tzAbbr = {
+        'Asia/Seoul': 'KST', 'Asia/Tokyo': 'JST', 'Asia/Shanghai': 'CST',
+        'America/New_York': 'EST', 'America/Chicago': 'CST', 'America/Denver': 'MST',
+        'America/Los_Angeles': 'PST', 'Europe/London': 'GMT', 'Europe/Paris': 'CET',
+        'Europe/Berlin': 'CET', 'Asia/Kolkata': 'IST', 'Asia/Calcutta': 'IST',
+        'Australia/Sydney': 'AEST', 'Pacific/Auckland': 'NZST',
+      };
+      const tz = tzAbbr[ianaZone] || target.toLocaleTimeString('en-US', { timeZoneName: 'short' }).split(' ').pop();
       return `${mon}/${day} ${hr}:${min} ${tz}`;
     }
     if (h > 0) return `${h}h ${m}m`;

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -1514,19 +1514,23 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       for (let i = 0; i < onlineAgents.length; i++) {
         const a = onlineAgents[i];
         const r = results[i];
+        const hostname = a.displayName || a.hostname || a.agentId;
         if (r.status === 'fulfilled' && r.value) {
           anySuccess = true;
-          newByAgent[a.agentId] = {
-            hostname: a.displayName || a.hostname || a.agentId,
-            data: r.value,
-          };
+          newByAgent[a.agentId] = { hostname, data: r.value };
+        } else {
+          // Keep failed agents visible with error indicator
+          const errMsg = r.status === 'rejected'
+            ? (r.reason?.message || 'Failed to fetch usage')
+            : 'No data';
+          newByAgent[a.agentId] = { hostname, data: null, error: errMsg };
         }
       }
+      agentsUsageByAgent = newByAgent;
       if (anySuccess) {
-        agentsUsageByAgent = newByAgent;
         // Keep legacy single-agent data as first result for header pct
-        const firstKey = Object.keys(newByAgent)[0];
-        agentsUsageData = newByAgent[firstKey].data;
+        const firstEntry = Object.values(newByAgent).find(e => e.data);
+        agentsUsageData = firstEntry ? firstEntry.data : null;
         agentsUsageLastUpdated = Date.now();
         agentsUsageFetchError = null;
       } else {
@@ -1620,13 +1624,17 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     }
 
     for (const entry of agentEntries) {
-      const d = entry.data;
-      if (!d) continue;
       // Always show machine name header with device color
       const dc = getDeviceColor(entry.hostname);
       const nameColor = dc ? dc.text : '#4ec9b0';
       const borderColor = dc ? dc.border : 'rgba(78,201,176,0.2)';
       blocks += `<div style="font-size:11px;color:${nameColor};margin:${blocks ? '10px' : '0'} 0 4px;font-weight:600;border-bottom:1px solid ${borderColor};padding-bottom:3px;">${entry.hostname}</div>`;
+      const d = entry.data;
+      if (!d) {
+        // Show error state for agents whose usage request failed
+        blocks += `<div style="font-size:11px;color:#e55;padding:4px 0;">Usage unavailable</div>`;
+        continue;
+      }
       addBlock('5-hour window', d.five_hour);
       addBlock('7-day window', d.seven_day);
       addBlock('7-day sonnet', d.seven_day_sonnet);
@@ -7408,11 +7416,30 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     // fit() itself changes the terminal element size.
     let fitting = false;
 
+    // When fit() increases rows, xterm absorbs scrollback lines into the
+    // visible area. tmux then repaints and overwrites those absorbed lines,
+    // permanently losing the scrollback. Track this and schedule a reattach
+    // to re-inject history from the agent.
+    let reattachTimer = null;
+
     function safeFit() {
       if (fitting) return;
       fitting = true;
       try {
+        const baseYBefore = xterm.buffer.active.baseY;
         fitAddon.fit();
+        const baseYAfter = xterm.buffer.active.baseY;
+
+        // Scrollback was absorbed — schedule a reattach to restore history.
+        // Debounced so rapid resizes only trigger one reattach.
+        if (baseYBefore > 0 && baseYAfter < baseYBefore) {
+          if (reattachTimer) clearTimeout(reattachTimer);
+          reattachTimer = setTimeout(() => {
+            reattachTimer = null;
+            const pane = state.panes.find(p => p.id === paneData.id);
+            if (pane) reattachTerminal(pane);
+          }, 600); // wait for tmux repaint to settle
+        }
       } catch (e) {
         // Ignore fit errors
       } finally {

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -4287,7 +4287,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
   // Shared folder-browse-then-scan picker used by git and beads repo pickers.
   // config: { id, headerHTML, scanLabel, onScan(folderPath, contentArea, closeBrowser, navigateFolder, navRefresh), device, targetAgentId }
   function showFolderScanPicker(config) {
-    const { id, headerHTML, scanLabel, onScan, device, targetAgentId } = config;
+    const { id, headerHTML, scanLabel, onScan, device, targetAgentId, startPath = '~' } = config;
     const { overlay, header, breadcrumbBar, contentArea, closeBrowser, addCleanup } = createBrowserOverlay(id, headerHTML);
 
     // Attach keyboard nav to the overlay (lives for entire overlay lifetime)
@@ -4339,7 +4339,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       }
     }
 
-    navigateFolder('~');
+    navigateFolder(startPath);
     return { closeBrowser };
   }
 
@@ -4594,7 +4594,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
   }
 
   // Show folder browser then repo picker for git graph pane
-  async function showGitRepoPicker(device, placementPos, thenPlace = false, targetAgentId) {
+  async function showGitRepoPicker(device, placementPos, thenPlace = false, targetAgentId, startPath) {
     const deviceLabel = device ? deviceLabelHtml(device, 'font-size:11px; padding:2px 8px;') : '';
     const headerHTML = `
       <svg viewBox="0 0 24 24" width="16" height="16" style="color:rgba(255,255,255,0.6);">${ICON_GIT_GRAPH}</svg>
@@ -4609,6 +4609,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       scanLabel: 'Scan this folder for repos',
       device,
       targetAgentId,
+      startPath,
       onScan: async (folderPath, contentArea, closeBrowser, navigateFolder, navRefresh) => {
         // Set up progressive UI immediately
         contentArea.innerHTML = '';
@@ -5037,6 +5038,9 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
         ${paneNameHtml(paneData)}
         <div class="pane-header-right">
           ${shortcutBadgeHtml(paneData)}
+          <button class="term-ctx-btn" data-action="file" aria-label="Browse files" data-tooltip="Browse files from cwd"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></button>
+          <button class="term-ctx-btn" data-action="git-graph" aria-label="Git graph" data-tooltip="Git graph from cwd"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="0">${ICON_GIT_GRAPH}</svg></button>
+          <button class="term-ctx-btn" data-action="folder" aria-label="Open folder" data-tooltip="Open folder from cwd"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg></button>
           <button class="beads-tag-btn" aria-label="Set beads issue" data-tooltip="Set beads issue"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="0">${ICON_BEADS}</svg></button>
           <button class="term-refresh-history" aria-label="Reload history" data-tooltip="Reload history"><svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M13 3a7 7 0 1 0 1 5"/><polyline points="14 1 14 5 10 5"/></svg></button>
           <div class="pane-zoom-controls">
@@ -7650,6 +7654,24 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       });
     }
 
+    // Terminal context buttons (File / Git Graph / Folder from cwd)
+    paneEl.querySelectorAll('.term-ctx-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const action = btn.dataset.action;
+        const cwd = paneData.workingDir || '~';
+        const device = paneData.device;
+        const agentId = paneData.agentId;
+        if (action === 'file') {
+          showFileBrowser(device, cwd, null, true, agentId);
+        } else if (action === 'git-graph') {
+          showGitRepoPicker(device, null, true, agentId, cwd);
+        } else if (action === 'folder') {
+          showFolderPickerThenPlace(agentId, device, cwd);
+        }
+      });
+    });
+
     // Beads tag removal via X button
     paneEl.addEventListener('click', (e) => {
       const removeBtn = e.target.closest('.beads-tag-remove');
@@ -9642,7 +9664,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     );
   }
 
-  async function showFolderPickerThenPlace(targetAgentId, device) {
+  async function showFolderPickerThenPlace(targetAgentId, device, startPath) {
     const deviceLabel = device ? deviceLabelHtml(device, 'font-size:11px; padding:2px 8px;') : '';
     const headerHTML = `
       <svg viewBox="0 0 24 24" width="16" height="16" style="color:rgba(255,255,255,0.6);">${ICON_FOLDER}</svg>
@@ -9655,6 +9677,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       scanLabel: 'Open this folder as a pane',
       device,
       targetAgentId,
+      startPath,
       onScan: async (folderPath, contentArea, closeBrowser, navigateFolder, navRefresh) => {
         closeBrowser();
         enterPlacementMode('folder', (pos) => createFolderPane(folderPath, pos, targetAgentId, device));

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -562,6 +562,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       clearTimeout(cloudLayoutTimers.get(paneId));
       cloudLayoutTimers.delete(paneId);
     }
+    cloudLayoutPending.delete(paneId);
     cloudFetch('DELETE', `/api/layouts/${paneId}`)
       .catch(e => console.error('[Cloud] Layout delete failed:', e.message));
   }

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -379,41 +379,71 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
   // Cloud layout persistence (debounced per-pane, 500ms)
   const cloudLayoutTimers = new Map();
+  // Track panes with pending saves so we can flush on page unload
+  const cloudLayoutPending = new Map(); // paneId -> pane ref
+
+  function buildLayoutPayload(pane) {
+    const metadata = {};
+    if (pane.zoomLevel && pane.zoomLevel !== 100) metadata.zoomLevel = pane.zoomLevel;
+    if (pane.textOnly) metadata.textOnly = true;
+    if (pane.type === 'folder' && pane.folderPath) metadata.folderPath = pane.folderPath;
+    if (pane.beadsTag) metadata.beadsTag = pane.beadsTag;
+    if (pane.device) metadata.device = pane.device;
+    if (pane.filePath) metadata.filePath = pane.filePath;
+    if (pane.fileName) metadata.fileName = pane.fileName;
+    if (pane.url) metadata.url = pane.url;
+    if (pane.repoPath) metadata.repoPath = pane.repoPath;
+    if (pane.repoName) metadata.repoName = pane.repoName;
+    if (pane.graphMode && pane.graphMode !== 'svg') metadata.graphMode = pane.graphMode;
+    if (pane.projectPath) metadata.projectPath = pane.projectPath;
+    if (pane.dirPath) metadata.dirPath = pane.dirPath;
+    if (pane.claudeSessionId) metadata.claudeSessionId = pane.claudeSessionId;
+    if (pane.claudeSessionName) metadata.claudeSessionName = pane.claudeSessionName;
+    if (pane.workingDir) metadata.workingDir = pane.workingDir;
+    if (pane.shortcutNumber) metadata.shortcutNumber = pane.shortcutNumber;
+    if (pane.paneName) metadata.paneName = pane.paneName;
+    return {
+      paneType: pane.type,
+      positionX: pane.x,
+      positionY: pane.y,
+      width: pane.width,
+      height: pane.height,
+      zIndex: pane.zIndex || 0,
+      agentId: pane.agentId || activeAgentId,
+      metadata: Object.keys(metadata).length > 0 ? metadata : null
+    };
+  }
+
   function cloudSaveLayout(pane) {
     if (cloudLayoutTimers.has(pane.id)) clearTimeout(cloudLayoutTimers.get(pane.id));
+    cloudLayoutPending.set(pane.id, pane);
     cloudLayoutTimers.set(pane.id, setTimeout(() => {
       cloudLayoutTimers.delete(pane.id);
-      const metadata = {};
-      if (pane.zoomLevel && pane.zoomLevel !== 100) metadata.zoomLevel = pane.zoomLevel;
-      if (pane.textOnly) metadata.textOnly = true;
-      if (pane.type === 'folder' && pane.folderPath) metadata.folderPath = pane.folderPath;
-      if (pane.beadsTag) metadata.beadsTag = pane.beadsTag;
-      if (pane.device) metadata.device = pane.device;
-      if (pane.filePath) metadata.filePath = pane.filePath;
-      if (pane.fileName) metadata.fileName = pane.fileName;
-      if (pane.url) metadata.url = pane.url;
-      if (pane.repoPath) metadata.repoPath = pane.repoPath;
-      if (pane.repoName) metadata.repoName = pane.repoName;
-      if (pane.graphMode && pane.graphMode !== 'svg') metadata.graphMode = pane.graphMode;
-      if (pane.projectPath) metadata.projectPath = pane.projectPath;
-      if (pane.dirPath) metadata.dirPath = pane.dirPath;
-      if (pane.claudeSessionId) metadata.claudeSessionId = pane.claudeSessionId;
-      if (pane.claudeSessionName) metadata.claudeSessionName = pane.claudeSessionName;
-      if (pane.workingDir) metadata.workingDir = pane.workingDir;
-      if (pane.shortcutNumber) metadata.shortcutNumber = pane.shortcutNumber;
-      if (pane.paneName) metadata.paneName = pane.paneName;
-      cloudFetch('PUT', `/api/layouts/${pane.id}`, {
-        paneType: pane.type,
-        positionX: pane.x,
-        positionY: pane.y,
-        width: pane.width,
-        height: pane.height,
-        zIndex: pane.zIndex || 0,
-        agentId: pane.agentId || activeAgentId,
-        metadata: Object.keys(metadata).length > 0 ? metadata : null
-      }).catch(e => console.error('[Cloud] Layout save failed:', e.message));
+      cloudLayoutPending.delete(pane.id);
+      cloudFetch('PUT', `/api/layouts/${pane.id}`, buildLayoutPayload(pane))
+        .catch(e => console.error('[Cloud] Layout save failed:', e.message));
     }, 500));
   }
+
+  // Flush any pending layout saves on page unload using keepalive fetch
+  // so positions are never lost when the user refreshes mid-debounce
+  window.addEventListener('beforeunload', () => {
+    for (const [paneId, pane] of cloudLayoutPending) {
+      if (cloudLayoutTimers.has(paneId)) {
+        clearTimeout(cloudLayoutTimers.get(paneId));
+        cloudLayoutTimers.delete(paneId);
+      }
+      const payload = buildLayoutPayload(pane);
+      fetch(`/api/layouts/${paneId}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        keepalive: true
+      }).catch(() => {});
+    }
+    cloudLayoutPending.clear();
+  });
 
   // Save a recent pane context to cloud (fire-and-forget)
   function saveRecentContext(paneType, context, label, agentId) {
@@ -538,9 +568,12 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
   // Cloud view state (debounced 1s)
   let cloudViewStateTimer = null;
+  let cloudViewStateDirty = false;
   function cloudSaveViewState() {
+    cloudViewStateDirty = true;
     if (cloudViewStateTimer) clearTimeout(cloudViewStateTimer);
     cloudViewStateTimer = setTimeout(() => {
+      cloudViewStateDirty = false;
       cloudFetch('PUT', '/api/view-state', {
         zoom: state.zoom,
         panX: state.panX,
@@ -548,6 +581,20 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       }).catch(e => console.error('[Cloud] View state save failed:', e.message));
     }, 1000);
   }
+
+  // Also flush view state on page unload
+  window.addEventListener('beforeunload', () => {
+    if (cloudViewStateDirty) {
+      if (cloudViewStateTimer) clearTimeout(cloudViewStateTimer);
+      fetch('/api/view-state', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ zoom: state.zoom, panX: state.panX, panY: state.panY }),
+        keepalive: true
+      }).catch(() => {});
+    }
+  });
 
   // Cloud note sync (debounced per-note, 500ms)
   const cloudNoteTimers = new Map();
@@ -8989,11 +9036,13 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
           <div class="mention-path">${escapeHtml(info.path)}</div>
           ${beadsInfo}
         </div>`;
-        overlay.addEventListener('click', (e) => {
+        overlay.addEventListener('mousedown', (e) => {
           e.stopPropagation();
+          e.preventDefault();
+          const encoded = btoa(unescape(encodeURIComponent(mentionPayload.text)));
           sendWs('terminal:input', {
             terminalId: paneData.id,
-            data: btoa(mentionPayload.text)
+            data: encoded
           }, paneData.agentId);
           // Auto-set beads tag when mentioning a beads issue to a terminal
           if (mentionPayload.type === 'beads' && mentionPayload.issueId) {

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -1553,14 +1553,15 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     if (diff <= 0) return 'now';
     const h = Math.floor(diff / 3600000);
     const m = Math.floor((diff % 3600000) / 60000);
-    // 24시간 이상이면 KST 절대 날짜/시간으로 표시
+    // 24시간 이상이면 브라우저 로컬 타임존 절대 날짜/시간으로 표시
     if (h >= 24) {
-      const kst = new Date(target.getTime() + 9 * 3600000);
-      const mon = kst.getUTCMonth() + 1;
-      const day = kst.getUTCDate();
-      const hr = String(kst.getUTCHours()).padStart(2, '0');
-      const min = String(kst.getUTCMinutes()).padStart(2, '0');
-      return `${mon}/${day} ${hr}:${min} KST`;
+      const mon = target.getMonth() + 1;
+      const day = target.getDate();
+      const hr = String(target.getHours()).padStart(2, '0');
+      const min = String(target.getMinutes()).padStart(2, '0');
+      // 짧은 타임존 약어 (e.g. KST, PST, EST)
+      const tz = Intl.DateTimeFormat('en', { timeZoneName: 'short' }).formatToParts(target).find(p => p.type === 'timeZoneName')?.value || '';
+      return `${mon}/${day} ${hr}:${min} ${tz}`;
     }
     if (h > 0) return `${h}h ${m}m`;
     return `${m}m`;

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -659,7 +659,8 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
   let hudHidden = false;
   let fleetPaneHidden = false;
   let agentsPaneHidden = false;
-  let agentsUsageData = null;
+  let agentsUsageData = null;       // legacy single-account (unused now)
+  let agentsUsageByAgent = {};      // agentId -> { hostname, data }
   let agentsUsageLastUpdated = null;
   let agentsUsageIntervalId = null;
   let agentsUsageFetchError = null;
@@ -1500,27 +1501,39 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
   }
 
   async function fetchAgentsUsage() {
-    // Query all online agents in parallel — use first successful response
-    // (usage data is per-account, so any online agent returns the same data)
+    // Query all online agents in parallel — collect per-agent results
     const onlineAgents = agents.filter(a => a.online);
     if (onlineAgents.length === 0) return;
     try {
       const results = await Promise.allSettled(
         onlineAgents.map(a => agentRequest('GET', '/api/usage', null, a.agentId))
       );
-      const first = results.find(r => r.status === 'fulfilled' && r.value);
-      if (first) {
-        agentsUsageData = first.value;
+      let anySuccess = false;
+      const newByAgent = {};
+      for (let i = 0; i < onlineAgents.length; i++) {
+        const a = onlineAgents[i];
+        const r = results[i];
+        if (r.status === 'fulfilled' && r.value) {
+          anySuccess = true;
+          newByAgent[a.agentId] = {
+            hostname: a.displayName || a.hostname || a.agentId,
+            data: r.value,
+          };
+        }
+      }
+      if (anySuccess) {
+        agentsUsageByAgent = newByAgent;
+        // Keep legacy single-agent data as first result for header pct
+        const firstKey = Object.keys(newByAgent)[0];
+        agentsUsageData = newByAgent[firstKey].data;
         agentsUsageLastUpdated = Date.now();
         agentsUsageFetchError = null;
-        renderAgentsHud();
       } else {
-        // All agents failed — extract first error for display
         const firstErr = results.find(r => r.status === 'rejected');
         agentsUsageFetchError = firstErr ? (firstErr.reason?.message || 'Failed to fetch usage') : 'No response from agents';
-        console.warn('[usage] All agents failed to return usage data:', results.map(r => r.status === 'rejected' ? r.reason?.message : 'fulfilled-empty').join(', '));
-        renderAgentsHud();
+        console.warn('[usage] All agents failed to return usage data');
       }
+      renderAgentsHud();
     } catch (e) {
       agentsUsageFetchError = e.message || 'Unexpected error';
       console.warn('[usage] fetchAgentsUsage error:', e);
@@ -1535,10 +1548,20 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
   }
 
   function agentsTimeUntil(isoDate) {
-    const diff = new Date(isoDate) - Date.now();
+    const target = new Date(isoDate);
+    const diff = target - Date.now();
     if (diff <= 0) return 'now';
     const h = Math.floor(diff / 3600000);
     const m = Math.floor((diff % 3600000) / 60000);
+    // 24시간 이상이면 KST 절대 날짜/시간으로 표시
+    if (h >= 24) {
+      const kst = new Date(target.getTime() + 9 * 3600000);
+      const mon = kst.getUTCMonth() + 1;
+      const day = kst.getUTCDate();
+      const hr = String(kst.getUTCHours()).padStart(2, '0');
+      const min = String(kst.getUTCMinutes()).padStart(2, '0');
+      return `${mon}/${day} ${hr}:${min} KST`;
+    }
     if (h > 0) return `${h}h ${m}m`;
     return `${m}m`;
   }
@@ -1550,12 +1573,20 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     const pctEl = hud.querySelector('#agents-hud-pct');
     const content = hud.querySelector('.agents-hud-content');
 
-    // Header: show shortest-term usage percentage
-    if (agentsUsageData && agentsUsageData.five_hour) {
-      const pct = agentsUsageData.five_hour.utilization;
-      const cls = agentsUsageColorClass(pct);
+    const agentEntries = Object.values(agentsUsageByAgent);
+
+    // Header: show worst (highest) 5-hour usage across all accounts
+    let worstPct = null;
+    for (const entry of agentEntries) {
+      if (entry.data && entry.data.five_hour) {
+        const p = entry.data.five_hour.utilization;
+        if (worstPct === null || p > worstPct) worstPct = p;
+      }
+    }
+    if (worstPct !== null) {
+      const cls = agentsUsageColorClass(worstPct);
       if (pctEl) {
-        pctEl.textContent = pct + '%';
+        pctEl.textContent = (agentEntries.length > 1 ? 'max ' : '') + worstPct + '%';
         pctEl.className = 'agents-hud-pct ' + cls;
       }
     } else if (pctEl) {
@@ -1568,8 +1599,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       return;
     }
 
-    // Expanded: usage bars
-    if (!agentsUsageData) {
+    if (agentEntries.length === 0) {
       content.innerHTML = '<div class="agents-empty">Loading...</div>';
       return;
     }
@@ -1595,10 +1625,19 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       `;
     }
 
-    addBlock('5-hour window', agentsUsageData.five_hour);
-    addBlock('7-day window', agentsUsageData.seven_day);
-    addBlock('7-day sonnet', agentsUsageData.seven_day_sonnet);
-    if (agentsUsageData.seven_day_opus) addBlock('7-day opus', agentsUsageData.seven_day_opus);
+    for (const entry of agentEntries) {
+      const d = entry.data;
+      if (!d) continue;
+      // Always show machine name header with device color
+      const dc = getDeviceColor(entry.hostname);
+      const nameColor = dc ? dc.text : '#4ec9b0';
+      const borderColor = dc ? dc.border : 'rgba(78,201,176,0.2)';
+      blocks += `<div style="font-size:11px;color:${nameColor};margin:${blocks ? '10px' : '0'} 0 4px;font-weight:600;border-bottom:1px solid ${borderColor};padding-bottom:3px;">${entry.hostname}</div>`;
+      addBlock('5-hour window', d.five_hour);
+      addBlock('7-day window', d.seven_day);
+      addBlock('7-day sonnet', d.seven_day_sonnet);
+      if (d.seven_day_opus) addBlock('7-day opus', d.seven_day_opus);
+    }
 
     // "Last updated" indicator + error state
     if (agentsUsageLastUpdated) {

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -379,41 +379,71 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
   // Cloud layout persistence (debounced per-pane, 500ms)
   const cloudLayoutTimers = new Map();
+  // Track panes with pending saves so we can flush on page unload
+  const cloudLayoutPending = new Map(); // paneId -> pane ref
+
+  function buildLayoutPayload(pane) {
+    const metadata = {};
+    if (pane.zoomLevel && pane.zoomLevel !== 100) metadata.zoomLevel = pane.zoomLevel;
+    if (pane.textOnly) metadata.textOnly = true;
+    if (pane.type === 'folder' && pane.folderPath) metadata.folderPath = pane.folderPath;
+    if (pane.beadsTag) metadata.beadsTag = pane.beadsTag;
+    if (pane.device) metadata.device = pane.device;
+    if (pane.filePath) metadata.filePath = pane.filePath;
+    if (pane.fileName) metadata.fileName = pane.fileName;
+    if (pane.url) metadata.url = pane.url;
+    if (pane.repoPath) metadata.repoPath = pane.repoPath;
+    if (pane.repoName) metadata.repoName = pane.repoName;
+    if (pane.graphMode && pane.graphMode !== 'svg') metadata.graphMode = pane.graphMode;
+    if (pane.projectPath) metadata.projectPath = pane.projectPath;
+    if (pane.dirPath) metadata.dirPath = pane.dirPath;
+    if (pane.claudeSessionId) metadata.claudeSessionId = pane.claudeSessionId;
+    if (pane.claudeSessionName) metadata.claudeSessionName = pane.claudeSessionName;
+    if (pane.workingDir) metadata.workingDir = pane.workingDir;
+    if (pane.shortcutNumber) metadata.shortcutNumber = pane.shortcutNumber;
+    if (pane.paneName) metadata.paneName = pane.paneName;
+    return {
+      paneType: pane.type,
+      positionX: pane.x,
+      positionY: pane.y,
+      width: pane.width,
+      height: pane.height,
+      zIndex: pane.zIndex || 0,
+      agentId: pane.agentId || activeAgentId,
+      metadata: Object.keys(metadata).length > 0 ? metadata : null
+    };
+  }
+
   function cloudSaveLayout(pane) {
     if (cloudLayoutTimers.has(pane.id)) clearTimeout(cloudLayoutTimers.get(pane.id));
+    cloudLayoutPending.set(pane.id, pane);
     cloudLayoutTimers.set(pane.id, setTimeout(() => {
       cloudLayoutTimers.delete(pane.id);
-      const metadata = {};
-      if (pane.zoomLevel && pane.zoomLevel !== 100) metadata.zoomLevel = pane.zoomLevel;
-      if (pane.textOnly) metadata.textOnly = true;
-      if (pane.type === 'folder' && pane.folderPath) metadata.folderPath = pane.folderPath;
-      if (pane.beadsTag) metadata.beadsTag = pane.beadsTag;
-      if (pane.device) metadata.device = pane.device;
-      if (pane.filePath) metadata.filePath = pane.filePath;
-      if (pane.fileName) metadata.fileName = pane.fileName;
-      if (pane.url) metadata.url = pane.url;
-      if (pane.repoPath) metadata.repoPath = pane.repoPath;
-      if (pane.repoName) metadata.repoName = pane.repoName;
-      if (pane.graphMode && pane.graphMode !== 'svg') metadata.graphMode = pane.graphMode;
-      if (pane.projectPath) metadata.projectPath = pane.projectPath;
-      if (pane.dirPath) metadata.dirPath = pane.dirPath;
-      if (pane.claudeSessionId) metadata.claudeSessionId = pane.claudeSessionId;
-      if (pane.claudeSessionName) metadata.claudeSessionName = pane.claudeSessionName;
-      if (pane.workingDir) metadata.workingDir = pane.workingDir;
-      if (pane.shortcutNumber) metadata.shortcutNumber = pane.shortcutNumber;
-      if (pane.paneName) metadata.paneName = pane.paneName;
-      cloudFetch('PUT', `/api/layouts/${pane.id}`, {
-        paneType: pane.type,
-        positionX: pane.x,
-        positionY: pane.y,
-        width: pane.width,
-        height: pane.height,
-        zIndex: pane.zIndex || 0,
-        agentId: pane.agentId || activeAgentId,
-        metadata: Object.keys(metadata).length > 0 ? metadata : null
-      }).catch(e => console.error('[Cloud] Layout save failed:', e.message));
+      cloudLayoutPending.delete(pane.id);
+      cloudFetch('PUT', `/api/layouts/${pane.id}`, buildLayoutPayload(pane))
+        .catch(e => console.error('[Cloud] Layout save failed:', e.message));
     }, 500));
   }
+
+  // Flush any pending layout saves on page unload using keepalive fetch
+  // so positions are never lost when the user refreshes mid-debounce
+  window.addEventListener('beforeunload', () => {
+    for (const [paneId, pane] of cloudLayoutPending) {
+      if (cloudLayoutTimers.has(paneId)) {
+        clearTimeout(cloudLayoutTimers.get(paneId));
+        cloudLayoutTimers.delete(paneId);
+      }
+      const payload = buildLayoutPayload(pane);
+      fetch(`/api/layouts/${paneId}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        keepalive: true
+      }).catch(() => {});
+    }
+    cloudLayoutPending.clear();
+  });
 
   // Save a recent pane context to cloud (fire-and-forget)
   function saveRecentContext(paneType, context, label, agentId) {
@@ -538,9 +568,12 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
   // Cloud view state (debounced 1s)
   let cloudViewStateTimer = null;
+  let cloudViewStateDirty = false;
   function cloudSaveViewState() {
+    cloudViewStateDirty = true;
     if (cloudViewStateTimer) clearTimeout(cloudViewStateTimer);
     cloudViewStateTimer = setTimeout(() => {
+      cloudViewStateDirty = false;
       cloudFetch('PUT', '/api/view-state', {
         zoom: state.zoom,
         panX: state.panX,
@@ -548,6 +581,20 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       }).catch(e => console.error('[Cloud] View state save failed:', e.message));
     }, 1000);
   }
+
+  // Also flush view state on page unload
+  window.addEventListener('beforeunload', () => {
+    if (cloudViewStateDirty) {
+      if (cloudViewStateTimer) clearTimeout(cloudViewStateTimer);
+      fetch('/api/view-state', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ zoom: state.zoom, panX: state.panX, panY: state.panY }),
+        keepalive: true
+      }).catch(() => {});
+    }
+  });
 
   // Cloud note sync (debounced per-note, 500ms)
   const cloudNoteTimers = new Map();
@@ -8889,11 +8936,13 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
           <div class="mention-path">${escapeHtml(info.path)}</div>
           ${beadsInfo}
         </div>`;
-        overlay.addEventListener('click', (e) => {
+        overlay.addEventListener('mousedown', (e) => {
           e.stopPropagation();
+          e.preventDefault();
+          const encoded = btoa(unescape(encodeURIComponent(mentionPayload.text)));
           sendWs('terminal:input', {
             terminalId: paneData.id,
-            data: btoa(mentionPayload.text)
+            data: encoded
           }, paneData.agentId);
           // Auto-set beads tag when mentioning a beads issue to a terminal
           if (mentionPayload.type === 'beads' && mentionPayload.issueId) {

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -1248,6 +1248,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
     // Remove focused state like QV does
     document.querySelectorAll('.pane.focused').forEach(p => p.classList.remove('focused'));
+    document.querySelectorAll('.pane.depth-blur').forEach(p => p.classList.remove('depth-blur'));
   }
 
   function clearDeviceHighlight() {
@@ -4084,19 +4085,19 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
   let createPaneQueue = Promise.resolve();
 
   // Create a new terminal pane
-  function createPane(device, placementPos, targetAgentId) {
-    const task = createPaneQueue.then(() => _createPaneImpl(device, placementPos, targetAgentId));
+  function createPane(device, placementPos, targetAgentId, workingDir) {
+    const task = createPaneQueue.then(() => _createPaneImpl(device, placementPos, targetAgentId, workingDir));
     createPaneQueue = task.catch(() => {});
     return task;
   }
 
-  async function _createPaneImpl(device, placementPos, targetAgentId) {
+  async function _createPaneImpl(device, placementPos, targetAgentId, workingDir) {
     const resolvedAgentId = targetAgentId || activeAgentId;
 
     const position = calcPlacementPos(placementPos, 300, 200);
 
     try {
-      const reqBody = { workingDir: '~', position, size: PANE_DEFAULTS['terminal'] };
+      const reqBody = { workingDir: workingDir || '~', position, size: PANE_DEFAULTS['terminal'] };
       if (device) reqBody.device = device;
       const terminal = await agentRequest('POST', '/api/terminals', reqBody, resolvedAgentId);
 
@@ -5038,6 +5039,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
         ${paneNameHtml(paneData)}
         <div class="pane-header-right">
           ${shortcutBadgeHtml(paneData)}
+          <button class="term-ctx-btn" data-action="clone" aria-label="Clone terminal" data-tooltip="Clone terminal"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
           <button class="term-ctx-btn" data-action="file" aria-label="Browse files" data-tooltip="Browse files from cwd"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></button>
           <button class="term-ctx-btn" data-action="git-graph" aria-label="Git graph" data-tooltip="Git graph from cwd"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="0">${ICON_GIT_GRAPH}</svg></button>
           <button class="term-ctx-btn" data-action="folder" aria-label="Open folder" data-tooltip="Open folder from cwd"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg></button>
@@ -7662,7 +7664,9 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
         const cwd = paneData.workingDir || '~';
         const device = paneData.device;
         const agentId = paneData.agentId;
-        if (action === 'file') {
+        if (action === 'clone') {
+          enterPlacementMode('terminal', (pos) => createPane(device, pos, agentId, cwd));
+        } else if (action === 'file') {
           showFileBrowser(device, cwd, null, true, agentId);
         } else if (action === 'git-graph') {
           showGitRepoPicker(device, null, true, agentId, cwd);
@@ -8529,7 +8533,21 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       paneEl.classList.add('focused');
       lastFocusedPaneId = paneData.id;
 
-      // Quick View: overlays stay on all panes (no interaction in this mode)
+      // Depth-of-field: blur only panes that overlap with the focused pane
+      const fx = paneData.x, fy = paneData.y;
+      const fw = paneData.width || 0, fh = paneData.height || 0;
+      for (const p of state.panes) {
+        if (p.id === paneData.id) continue;
+        const el = document.getElementById(`pane-${p.id}`);
+        if (!el) continue;
+        const pw = p.width || 0, ph = p.height || 0;
+        const overlaps = fx < p.x + pw && fx + fw > p.x && fy < p.y + ph && fy + fh > p.y;
+        if (overlaps) {
+          el.classList.add('depth-blur');
+        } else {
+          el.classList.remove('depth-blur');
+        }
+      }
     }
   }
 
@@ -8802,6 +8820,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       });
       // Remove focused state from all panes
       document.querySelectorAll('.pane.focused').forEach(p => p.classList.remove('focused'));
+    document.querySelectorAll('.pane.depth-blur').forEach(p => p.classList.remove('depth-blur'));
     } else {
       document.querySelectorAll('.quick-view-overlay').forEach(o => o.remove());
       document.querySelectorAll('.pane.qv-hover').forEach(p => p.classList.remove('qv-hover'));
@@ -10458,6 +10477,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     document.body.classList.add('cursor-suppressed');
     // Clear all focused outlines — move mode has its own visual system
     document.querySelectorAll('.pane.focused').forEach(p => p.classList.remove('focused'));
+    document.querySelectorAll('.pane.depth-blur').forEach(p => p.classList.remove('depth-blur'));
     moveModeOriginalZoom = state.zoom;
 
     // Determine starting pane: last focused, or nearest to screen center

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -1584,23 +1584,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
     const agentEntries = Object.values(agentsUsageByAgent);
 
-    // Header: show worst (highest) 5-hour usage across all accounts
-    let worstPct = null;
-    for (const entry of agentEntries) {
-      if (entry.data && entry.data.five_hour) {
-        const p = entry.data.five_hour.utilization;
-        if (worstPct === null || p > worstPct) worstPct = p;
-      }
-    }
-    if (worstPct !== null) {
-      const cls = agentsUsageColorClass(worstPct);
-      if (pctEl) {
-        pctEl.textContent = (agentEntries.length > 1 ? 'max ' : '') + worstPct + '%';
-        pctEl.className = 'agents-hud-pct ' + cls;
-      }
-    } else if (pctEl) {
-      pctEl.textContent = '';
-    }
+    if (pctEl) pctEl.textContent = '';
 
     // Collapsed: no content
     if (!agentsHudExpanded) {

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -2036,7 +2036,9 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
       // Update paneData.workingDir from live tmux cwd
       if (paneData && info && info.cwd) {
+        const cwdChanged = paneData.workingDir !== info.cwd;
         paneData.workingDir = info.cwd;
+        if (cwdChanged) renderConnectionLines();
       }
       // Update Claude session ID/name and persist to cloud when they change
       if (paneData && info && info.claudeSessionId) {
@@ -3778,6 +3780,9 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     if (lastReceivedClaudeStates) {
       updateClaudeStates(lastReceivedClaudeStates);
     }
+
+    // Draw connection lines after all panes are loaded
+    renderConnectionLines();
   }
 
   /**
@@ -4929,6 +4934,8 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       // Remove from cloud layout
       cloudDeleteLayout(paneId);
 
+      renderConnectionLines();
+
     } catch (e) {
       console.error('[App] Error deleting pane:', e);
     }
@@ -5993,6 +6000,9 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
         ${paneNameHtml(paneData)}
         <div class="pane-header-right">
           ${shortcutBadgeHtml(paneData)}
+          <button class="folder-toolbar-btn follow-pin-btn" data-tooltip="${paneData._pinned ? 'Unpin (follow terminal)' : 'Pin path (stop following)'}" style="color:${paneData._pinned ? '#e8a060' : 'rgba(255,255,255,0.4)'};">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="${paneData._pinned ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2"><path d="M12 2C9.24 2 7 4.24 7 7c0 1.38.56 2.63 1.46 3.54L12 22l3.54-11.46A5 5 0 0 0 17 7c0-2.76-2.24-5-5-5z"/><circle cx="12" cy="7" r="1.5" fill="${paneData._pinned ? '#1a1a2e' : 'none'}"/></svg>
+          </button>
           <button class="folder-toolbar-btn folder-new-file-btn" data-tooltip="New File">
             <svg viewBox="0 0 24 24" width="14" height="14"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6z" fill="none" stroke="currentColor" stroke-width="2"/><line x1="12" y1="11" x2="12" y2="17" stroke="currentColor" stroke-width="2"/><line x1="9" y1="14" x2="15" y2="14" stroke="currentColor" stroke-width="2"/></svg>
           </button>
@@ -6261,6 +6271,17 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       } catch (e) {
         alert('Failed to open file: ' + e.message);
       }
+    }
+
+    // Toolbar: Pin/Unpin (follow mode)
+    const pinBtn = pane.querySelector('.follow-pin-btn');
+    if (pinBtn) {
+      pinBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        paneData._pinned = !paneData._pinned;
+        // Re-render to update button state
+        renderFolderPane(paneData);
+      });
     }
 
     // Toolbar: New File
@@ -7863,6 +7884,11 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       }
       focusPane(paneData);
       focusTerminalInput(paneData.id);
+      // Follow mode: only on click (not hover) to avoid path changes while passing through panes
+      if (paneData.type === 'terminal' && paneData.workingDir) {
+        if (followModeDebounce) clearTimeout(followModeDebounce);
+        followModeDebounce = setTimeout(() => triggerFollowMode(paneData), 200);
+      }
     }, true); // capture phase
 
     // Track touch start position for tap-vs-drag detection
@@ -8307,6 +8333,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       } else {
         cloudSaveLayout(paneData);
       }
+      renderConnectionLines();
 
       document.removeEventListener('mousemove', moveHandler);
       document.removeEventListener('touchmove', moveHandler);
@@ -8436,6 +8463,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
       // Save size to cloud (cloud-only, no agent write)
       cloudSaveLayout(paneData);
+      renderConnectionLines();
 
       document.removeEventListener('mousemove', moveHandler);
       document.removeEventListener('touchmove', moveHandler);
@@ -8477,6 +8505,52 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
       // Quick View: overlays stay on all panes (no interaction in this mode)
     }
+
+  }
+
+  // ── Follow Mode: folder/git-graph panes follow focused terminal ──
+  let followModeDebounce = null;
+
+  function triggerFollowMode(terminalPane) {
+    if (!terminalPane || terminalPane.type !== 'terminal') return;
+    const cwd = terminalPane.workingDir;
+    if (!cwd) return;
+
+    // Find unpinned folder panes (only follow if exactly 1)
+    const unpinnedFolders = state.panes.filter(p =>
+      p.type === 'folder' && !p._pinned && p.agentId === terminalPane.agentId
+    );
+    if (unpinnedFolders.length === 1) {
+      const fp = unpinnedFolders[0];
+      const normCwd = normPath(cwd);
+      if (normPath(fp.folderPath) !== normCwd) {
+        fp.folderPath = cwd;
+        renderFolderPane(fp);
+        cloudSaveLayout(fp);
+      }
+    }
+
+    // Find unpinned git-graph panes (only follow if exactly 1)
+    const unpinnedGitGraphs = state.panes.filter(p =>
+      p.type === 'git-graph' && !p._pinned && p.agentId === terminalPane.agentId
+    );
+    if (unpinnedGitGraphs.length === 1) {
+      const gg = unpinnedGitGraphs[0];
+      // Use the terminal's cwd — the agent's fetchGraphData will resolve git root
+      // We need to update the repoPath on the agent via PATCH, then re-render
+      if (normPath(gg.repoPath) !== normPath(cwd)) {
+        agentRequest('PATCH', `/api/git-graphs/${gg.id}`, { repoPath: cwd }, gg.agentId)
+          .then(() => {
+            gg.repoPath = cwd;
+            gg.repoName = cwd.split('/').pop();
+            renderGitGraphPane(gg);
+            cloudSaveLayout(gg);
+          })
+          .catch(() => {}); // silently fail if not a git repo
+      }
+    }
+
+    renderConnectionLines();
   }
 
   // Pan canvas to center a pane and focus it
@@ -8507,6 +8581,169 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
   // Update canvas transform
   function updateCanvasTransform() {
     canvas.style.transform = `translate(${state.panX}px, ${state.panY}px) scale(${state.zoom})`;
+  }
+
+  // ============================================================================
+  // PANE CONNECTION LINES — SVG lines between related panes sharing a path
+  // ============================================================================
+
+  const CONNECTION_COLORS = [
+    { line: 'rgba(78,201,176,0.35)',  dot: 'rgba(78,201,176,0.6)' },   // teal
+    { line: 'rgba(200,130,240,0.35)', dot: 'rgba(200,130,240,0.6)' },   // purple
+    { line: 'rgba(240,180,80,0.35)',  dot: 'rgba(240,180,80,0.6)' },    // amber
+    { line: 'rgba(100,180,255,0.35)', dot: 'rgba(100,180,255,0.6)' },   // blue
+    { line: 'rgba(255,120,140,0.35)', dot: 'rgba(255,120,140,0.6)' },   // pink
+    { line: 'rgba(130,220,100,0.35)', dot: 'rgba(130,220,100,0.6)' },   // green
+    { line: 'rgba(255,160,100,0.35)', dot: 'rgba(255,160,100,0.6)' },   // orange
+    { line: 'rgba(160,200,255,0.35)', dot: 'rgba(160,200,255,0.6)' },   // ice
+  ];
+
+  function getConnectionColor(pathKey) {
+    let hash = 0;
+    for (let i = 0; i < pathKey.length; i++) {
+      hash = ((hash << 5) - hash + pathKey.charCodeAt(i)) | 0;
+    }
+    return CONNECTION_COLORS[Math.abs(hash) % CONNECTION_COLORS.length];
+  }
+
+  function getPaneGroupPath(pane) {
+    if (pane.type === 'terminal') return pane.workingDir || null;
+    if (pane.type === 'folder')  return pane.folderPath || null;
+    if (pane.type === 'git-graph') return pane.repoPath || null;
+    if (pane.type === 'file') {
+      const fp = pane.filePath;
+      if (!fp) return null;
+      const idx = fp.lastIndexOf('/');
+      return idx > 0 ? fp.slice(0, idx) : null;
+    }
+    return null;
+  }
+
+  // Normalize path: remove trailing slash, collapse //
+  function normPath(p) {
+    if (!p) return null;
+    return p.replace(/\/+$/, '').replace(/\/\/+/g, '/') || '/';
+  }
+
+  let connectionSvg = null;
+  let connectionRafId = null;
+
+  function ensureConnectionSvg() {
+    if (connectionSvg && connectionSvg.parentNode === canvas) return connectionSvg;
+    connectionSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    connectionSvg.id = 'pane-connections';
+    connectionSvg.style.cssText = 'position:absolute;top:0;left:0;width:10000px;height:10000px;pointer-events:none;z-index:0;overflow:visible;';
+    canvas.insertBefore(connectionSvg, canvas.firstChild);
+    return connectionSvg;
+  }
+
+  function renderConnectionLines() {
+    if (connectionRafId) return;
+    connectionRafId = requestAnimationFrame(() => {
+      connectionRafId = null;
+      _renderConnectionLines();
+    });
+  }
+
+  // Find the closest edge point between two panes and return connection anchors
+  function getEdgeAnchors(a, b) {
+    const aw = a.width || 0, ah = a.height || 0;
+    const bw = b.width || 0, bh = b.height || 0;
+    const acx = a.x + aw / 2, acy = a.y + ah / 2;
+    const bcx = b.x + bw / 2, bcy = b.y + bh / 2;
+    const dx = bcx - acx, dy = bcy - acy;
+    const absDx = Math.abs(dx), absDy = Math.abs(dy);
+
+    let ax1, ay1, bx1, by1, dir;
+
+    if (absDx > absDy) {
+      // Horizontal: connect left/right edges
+      dir = 'h';
+      if (dx > 0) {
+        ax1 = a.x + aw; ay1 = acy; // right edge of A
+        bx1 = b.x;      by1 = bcy; // left edge of B
+      } else {
+        ax1 = a.x;       ay1 = acy; // left edge of A
+        bx1 = b.x + bw;  by1 = bcy; // right edge of B
+      }
+    } else {
+      // Vertical: connect top/bottom edges
+      dir = 'v';
+      if (dy > 0) {
+        ax1 = acx; ay1 = a.y + ah; // bottom edge of A
+        bx1 = bcx; by1 = b.y;      // top edge of B
+      } else {
+        ax1 = acx; ay1 = a.y;      // top edge of A
+        bx1 = bcx; by1 = b.y + bh; // bottom edge of B
+      }
+    }
+
+    return { ax: ax1, ay: ay1, bx: bx1, by: by1, dir };
+  }
+
+  function _renderConnectionLines() {
+    const svg = ensureConnectionSvg();
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+    // Group panes by normalized path + agentId
+    const groups = new Map();
+    for (const pane of state.panes) {
+      const raw = getPaneGroupPath(pane);
+      const p = normPath(raw);
+      if (!p) continue;
+      const key = `${pane.agentId || ''}::${p}`;
+      if (!groups.has(key)) groups.set(key, { path: p, panes: [] });
+      groups.get(key).panes.push(pane);
+    }
+
+    for (const [, group] of groups) {
+      if (group.panes.length < 2) continue;
+      const color = getConnectionColor(group.path);
+      const panes = group.panes;
+
+      for (let i = 0; i < panes.length; i++) {
+        for (let j = i + 1; j < panes.length; j++) {
+          const { ax, ay, bx, by, dir } = getEdgeAnchors(panes[i], panes[j]);
+
+          // Cubic bezier control points — offset along the connection direction
+          const dist = Math.hypot(bx - ax, by - ay);
+          const offset = Math.min(dist * 0.4, 120);
+          let c1x, c1y, c2x, c2y;
+          if (dir === 'h') {
+            const sign = bx > ax ? 1 : -1;
+            c1x = ax + offset * sign; c1y = ay;
+            c2x = bx - offset * sign; c2y = by;
+          } else {
+            const sign = by > ay ? 1 : -1;
+            c1x = ax; c1y = ay + offset * sign;
+            c2x = bx; c2y = by - offset * sign;
+          }
+
+          const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+          path.setAttribute('d', `M${ax},${ay} C${c1x},${c1y} ${c2x},${c2y} ${bx},${by}`);
+          path.setAttribute('stroke', color.line);
+          path.setAttribute('stroke-width', '2');
+          path.setAttribute('fill', 'none');
+          path.setAttribute('stroke-dasharray', '6 4');
+          svg.appendChild(path);
+
+          // Dots at edge anchor points
+          const dotA = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          dotA.setAttribute('cx', ax);
+          dotA.setAttribute('cy', ay);
+          dotA.setAttribute('r', '3');
+          dotA.setAttribute('fill', color.dot);
+          svg.appendChild(dotA);
+
+          const dotB = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          dotB.setAttribute('cx', bx);
+          dotB.setAttribute('cy', by);
+          dotB.setAttribute('r', '3');
+          dotB.setAttribute('fill', color.dot);
+          svg.appendChild(dotB);
+        }
+      }
+    }
   }
 
   // Quick View: overlay showing pane type, device, path, claude state

--- a/cloud/src-client/modules/git-graph.js
+++ b/cloud/src-client/modules/git-graph.js
@@ -607,7 +607,44 @@ export async function fetchGitGraphData(paneEl, paneData) {
     const statusEl = paneEl.querySelector('.git-graph-status');
 
     if (data.error) {
-      outputEl.innerHTML = `<span class="git-graph-error">Error: ${data.error}</span>`;
+      const isNotRepo = /not a git repository|not.*work.tree/i.test(data.error);
+      if (isNotRepo) {
+        const shortPath = (data.repoPath || paneData.repoPath || '').replace(/^\/home\/[^/]+/, '~');
+        branchEl.textContent = '';
+        statusEl.textContent = '';
+        // Safe DOM construction for non-repo state
+        outputEl.textContent = '';
+        const wrap = document.createElement('div');
+        wrap.className = 'git-graph-no-repo';
+        const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        icon.setAttribute('viewBox', '0 0 24 24');
+        icon.setAttribute('width', '32');
+        icon.setAttribute('height', '32');
+        icon.setAttribute('fill', 'none');
+        icon.setAttribute('stroke', 'rgba(255,255,255,0.15)');
+        icon.setAttribute('stroke-width', '1.5');
+        const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        circle.setAttribute('cx', '12'); circle.setAttribute('cy', '12'); circle.setAttribute('r', '10');
+        const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path1.setAttribute('d', 'M12 8v4');
+        const path2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path2.setAttribute('d', 'M12 16h.01');
+        icon.append(circle, path1, path2);
+        const label = document.createElement('div');
+        label.className = 'git-graph-no-repo-label';
+        label.textContent = 'Not a git repository';
+        const pathEl = document.createElement('div');
+        pathEl.className = 'git-graph-no-repo-path';
+        pathEl.textContent = shortPath;
+        wrap.append(icon, label, pathEl);
+        outputEl.appendChild(wrap);
+      } else {
+        const errEl = document.createElement('span');
+        errEl.className = 'git-graph-error';
+        errEl.textContent = data.error;
+        outputEl.textContent = '';
+        outputEl.appendChild(errEl);
+      }
       return;
     }
 

--- a/cloud/src-client/modules/git-graph.js
+++ b/cloud/src-client/modules/git-graph.js
@@ -49,6 +49,9 @@ export function renderGitGraphPane(paneData) {
       ${_ctx.paneNameHtml(paneData)}
       <div class="pane-header-right">
         ${_ctx.shortcutBadgeHtml(paneData)}
+        <button class="folder-toolbar-btn follow-pin-btn" data-tooltip="${paneData._pinned ? 'Unpin (follow terminal)' : 'Pin path (stop following)'}" style="color:${paneData._pinned ? '#e8a060' : 'rgba(255,255,255,0.4)'};">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="${paneData._pinned ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2"><path d="M12 2C9.24 2 7 4.24 7 7c0 1.38.56 2.63 1.46 3.54L12 22l3.54-11.46A5 5 0 0 0 17 7c0-2.76-2.24-5-5-5z"/><circle cx="12" cy="7" r="1.5" fill="${paneData._pinned ? '#1a1a2e' : 'none'}"/></svg>
+        </button>
         <div class="pane-zoom-controls">
           <button class="pane-zoom-btn zoom-out" data-tooltip="Zoom out">\u2212</button>
           <button class="pane-zoom-btn zoom-in" data-tooltip="Zoom in">+</button>
@@ -82,6 +85,16 @@ function setupGitGraphListeners(paneEl, paneData) {
   const graphOutput = paneEl.querySelector('.git-graph-output');
   const pushBtn = paneEl.querySelector('.git-graph-push-btn');
   const modeBtn = paneEl.querySelector('.git-graph-mode-btn');
+
+  // Pin/Unpin (follow mode)
+  const pinBtn = paneEl.querySelector('.follow-pin-btn');
+  if (pinBtn) {
+    pinBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      paneData._pinned = !paneData._pinned;
+      renderGitGraphPane(paneData);
+    });
+  }
 
   if (!paneData.graphMode) paneData.graphMode = 'svg';
 

--- a/cloud/src-client/modules/git-graph.js
+++ b/cloud/src-client/modules/git-graph.js
@@ -425,16 +425,23 @@ export function renderSvgGitGraph(outputEl, commits, currentBranch) {
 
     let refsHtml = '';
     if (commit.refs) {
+      // Match ref badge colors to graph line color for this commit
+      const hexToRgb = (hex) => {
+        const h = hex.replace('#', '');
+        return `${parseInt(h.slice(0,2),16)},${parseInt(h.slice(2,4),16)},${parseInt(h.slice(4,6),16)}`;
+      };
+      const rgb = hexToRgb(colour);
+      const refStyle = `background:rgba(${rgb},0.15);color:${colour};border:1px solid rgba(${rgb},0.3)`;
       const refParts = commit.refs.split(',').map(r => r.trim()).filter(Boolean);
       for (const ref of refParts) {
         if (ref.startsWith('HEAD -> ')) {
-          refsHtml += `<span class="gg-ref gg-ref-head">${escapeHtml(ref.replace('HEAD -> ', ''))}</span>`;
+          refsHtml += `<span class="gg-ref gg-ref-head" style="${refStyle}">${escapeHtml(ref.replace('HEAD -> ', ''))}</span>`;
         } else if (ref.startsWith('tag: ')) {
           refsHtml += `<span class="gg-ref gg-ref-tag">${escapeHtml(ref.replace('tag: ', ''))}</span>`;
         } else if (ref.startsWith('origin/')) {
-          refsHtml += `<span class="gg-ref gg-ref-remote">${escapeHtml(ref)}</span>`;
+          refsHtml += `<span class="gg-ref gg-ref-remote" style="${refStyle}">${escapeHtml(ref)}</span>`;
         } else {
-          refsHtml += `<span class="gg-ref gg-ref-branch">${escapeHtml(ref)}</span>`;
+          refsHtml += `<span class="gg-ref gg-ref-branch" style="${refStyle}">${escapeHtml(ref)}</span>`;
         }
       }
     }

--- a/cloud/src/db/agents.js
+++ b/cloud/src/db/agents.js
@@ -73,6 +73,21 @@ export function updateAgentDisplayName(agentId, displayName) {
 }
 
 /**
+ * Ensure an agent exists in the DB (creates if missing).
+ * Needed for dev mode where agents bypass the registration flow.
+ */
+export function ensureAgentExists(agentId, userId, hostname, os) {
+  const db = getDb();
+  const existing = db.prepare('SELECT id FROM agents WHERE id = ?').get(agentId);
+  if (!existing) {
+    db.prepare(`
+      INSERT INTO agents (id, user_id, hostname, os, token_hash)
+      VALUES (?, ?, ?, ?, 'dev')
+    `).run(agentId, userId, hostname, os || null);
+  }
+}
+
+/**
  * Delete an agent by ID.
  */
 export function deleteAgent(agentId) {

--- a/cloud/src/index.js
+++ b/cloud/src/index.js
@@ -73,15 +73,17 @@ app.use(
           "'unsafe-inline'",  // Required for Monaco AMD loader config in index.html
           "https://cdnjs.cloudflare.com",
           "https://cdn.jsdelivr.net",
+          "blob:",  // Monaco web workers + extension scripts
         ],
-        styleSrc: ["'self'", "'unsafe-inline'", "https://cdnjs.cloudflare.com"],
-        fontSrc: ["'self'", "https://cdnjs.cloudflare.com", "data:"],
+        styleSrc: ["'self'", "'unsafe-inline'", "https://cdnjs.cloudflare.com", "https://fonts.googleapis.com"],
+        fontSrc: ["'self'", "https://cdnjs.cloudflare.com", "https://fonts.gstatic.com", "data:"],
         imgSrc: ["'self'", "data:", "blob:", "https:"],
-        connectSrc: ["'self'", "ws:", "wss:"],
+        connectSrc: ["'self'", "ws:", "wss:", "https://cdnjs.cloudflare.com", "https://cdn.jsdelivr.net"],
         workerSrc: ["'self'", "blob:"],  // Monaco web workers
-        frameSrc: ["'self'", "https:"],  // Iframe panes
+        frameSrc: ["'self'", "https:", "http:"],  // Iframe panes (allow HTTP for LAN)
         objectSrc: ["'none'"],
         baseUri: ["'self'"],
+        upgradeInsecureRequests: null,  // Disable HTTPS forcing for LAN/Tailscale HTTP access
       },
     },
     crossOriginEmbedderPolicy: false, // Allow embedding iframes in the canvas

--- a/cloud/src/routes/layouts.js
+++ b/cloud/src/routes/layouts.js
@@ -44,8 +44,13 @@ export function setupLayoutRoutes(app) {
 
   // PUT /api/layouts/:paneId — upsert a single pane layout
   app.put('/api/layouts/:paneId', requireAuth, (req, res) => {
-    upsertPaneLayout(req.user.id, { id: req.params.paneId, ...req.body });
-    res.json({ ok: true });
+    try {
+      upsertPaneLayout(req.user.id, { id: req.params.paneId, ...req.body });
+      res.json({ ok: true });
+    } catch (e) {
+      console.error(`[layouts] PUT /api/layouts/${req.params.paneId} failed:`, e.message);
+      res.status(500).json({ error: e.message });
+    }
   });
 
   // DELETE /api/layouts/:paneId — remove a pane from cloud layout

--- a/cloud/src/ws/agentHandler.js
+++ b/cloud/src/ws/agentHandler.js
@@ -16,7 +16,7 @@
 
 import { WebSocket } from 'ws';
 import { verifyAgentToken } from '../auth/agentAuth.js';
-import { updateLastSeen, getAgentById } from '../db/agents.js';
+import { updateLastSeen, getAgentById, ensureAgentExists } from '../db/agents.js';
 import { checkAgentLimit } from '../billing/enforcement.js';
 import { recordEvent } from '../db/events.js';
 import { isVersionOutdated } from '../utils/version.js';
@@ -88,7 +88,8 @@ export function handleAgentConnection(ws, userAgents, userBrowsers, latestAgentV
             }
             // Normalize OS name: Node's process.platform reports 'darwin' but UI expects 'macos'
             const agentOs = msg.payload.os === 'darwin' ? 'macos' : (msg.payload.os || 'unknown');
-            // Look up created_at from DB for chronological ordering
+            // Ensure agent exists in DB (dev mode skips registration)
+            ensureAgentExists(agentId, userId, msg.payload.hostname || 'unknown', agentOs);
             const agentRecord = getAgentById(agentId);
             const createdAt = agentRecord?.created_at || new Date().toISOString();
             userAgents.get(userId).set(agentId, {


### PR DESCRIPTION
## Summary
- **Per-machine usage tracking**: Collect and display usage data individually per machine instead of using a single-account model. The expanded view groups usage bars under each machine name with device colors.
- **Local timezone display**: For usage resets more than 24 hours away, show absolute date/time in the browser's local timezone with proper abbreviations (KST, PST, EST) using an IANA timezone mapping with toLocaleTimeString fallback.
- **Clean header**: Removed the "max X%" text from the collapsed usage header — detailed usage is visible in the expanded per-machine view.
- **CSP policy relaxation**: Allow blob: scripts for Monaco web workers, Google Fonts, HTTP iframes for LAN access, and disable upgradeInsecureRequests for Tailscale/LAN environments.