### PR TITLE
docs(readme): embed the demo video above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   <a href="https://twitter.com/49agents"><img src="https://img.shields.io/twitter/follow/49agents" alt="Twitter Follow" /></a>
 </p>
 
+https://github.com/user-attachments/assets/b2b038df-4100-490e-8bae-42965d5faca5
+
 <h1 align="center">
   Before
 </h1>


### PR DESCRIPTION
Adds the 36s demo video from #34 to the README, directly under the badge block and above the Before/49 comparison.

Placed as a bare URL on its own line rather than a `<video>` tag or an `<img>` inside the centered header: GitHub's sanitizer strips `<video>`, and a bare URL only expands into a player as a top-level paragraph — inside `<p align="center">` it renders as a dead link. So the player is full-width and cannot be centered.

Two-line diff, no other changes.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)