### PR TITLE
docs(readme): drop the Discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 <p align="center">
   <a href="https://github.com/49Agents/49Agents/stargazers"><img src="https://img.shields.io/github/stars/49Agents/49Agents?style=flat" alt="GitHub Stars" /></a>
-  <a href="https://discord.gg/rkUbxYvGj"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://twitter.com/49agents"><img src="https://img.shields.io/twitter/follow/49agents" alt="Twitter Follow" /></a>
 </p>
 


### PR DESCRIPTION
Removes the `discord.gg/rkUbxYvGj` invite badge from the README badge row. Stars and Twitter badges untouched.

Scope note: this removes only the public invite link in the README. Discord references elsewhere in the repo are left alone — see the PR discussion.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)