### PR TITLE
Fix terminals echoing every keystroke once per stale attachment

### DIFF
--- a/agent/src/terminalManager.js
+++ b/agent/src/terminalManager.js
@@ -95,6 +95,39 @@ try {
   // Ignore errors
 }
 
+/**
+ * True while a ttyd socket can still carry traffic. CONNECTING counts: the
+ * attach path awaits the open handshake, so a socket mid-handshake is a
+ * pending attachment rather than a dead one.
+ */
+function isSocketUsable(ws) {
+  return !!ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING);
+}
+
+/**
+ * Drop an attachment: silence its listeners, close its socket, and forget it.
+ *
+ * Removing the listeners is the part that matters. A closed socket stops
+ * delivering, but one that is merely superseded keeps its 'message' handler
+ * alive and keeps writing into the same terminal's emitter — which is how a
+ * terminal ends up echoing each keystroke once per stale attachment.
+ */
+function discardAttachment(terminalId, attachment) {
+  if (!attachment) return;
+  const { ttydWs } = attachment;
+  if (ttydWs) {
+    try { ttydWs.removeAllListeners(); } catch { /* already gone */ }
+    try {
+      if (ttydWs.readyState === WebSocket.OPEN || ttydWs.readyState === WebSocket.CONNECTING) {
+        ttydWs.close();
+      }
+    } catch { /* already closing */ }
+  }
+  if (activeTerminals.get(terminalId) === attachment) {
+    activeTerminals.delete(terminalId);
+  }
+}
+
 function getAvailablePort() {
   for (let port = BASE_PORT; port <= MAX_PORT; port++) {
     if (!usedPorts.has(port)) {
@@ -230,10 +263,20 @@ export const terminalManager = {
    *   'error' (message) — error occurred
    */
   async attachTerminal(terminalId, cols, rows) {
-    // If already attached, return existing emitter
+    // Reuse the existing attachment only while its socket is actually usable.
+    // A cached entry whose ttyd connection has died (agent restart, ttyd
+    // killed, network drop) would otherwise be handed back forever, and the
+    // terminal would look attached while receiving nothing.
     const existing = activeTerminals.get(terminalId);
     if (existing) {
-      return existing.emitter;
+      if (isSocketUsable(existing.ttydWs)) {
+        return existing.emitter;
+      }
+      // Dead socket: tear it down before attaching again, so its listeners
+      // stop forwarding and we do not end up with two sockets feeding the
+      // same terminal (which duplicates every keystroke and every byte of
+      // output the terminal produces).
+      discardAttachment(terminalId, existing);
     }
 
     // If another attachTerminal call is already in-flight for this id,
@@ -281,6 +324,15 @@ export const terminalManager = {
         } else {
           throw err;
         }
+      }
+
+      // Another attachment may have been registered while we were connecting.
+      // Replacing it without closing it would leave its listeners forwarding
+      // the same terminal, so every keystroke and every byte of output would
+      // arrive twice.
+      const superseded = activeTerminals.get(terminalId);
+      if (superseded && superseded.ttydWs !== ttydWs) {
+        discardAttachment(terminalId, superseded);
       }
 
       activeTerminals.set(terminalId, { ttydWs, emitter });
@@ -379,8 +431,7 @@ export const terminalManager = {
     const conn = activeTerminals.get(terminalId);
     if (conn && conn.ttydWs) {
       flushOutput(terminalId);
-      conn.ttydWs.close();
-      activeTerminals.delete(terminalId);
+      discardAttachment(terminalId, conn);
     }
 
     if (terminal) {
@@ -396,8 +447,7 @@ export const terminalManager = {
     const conn = activeTerminals.get(terminalId);
     if (conn && conn.ttydWs) {
       flushOutput(terminalId);
-      conn.ttydWs.close();
-      activeTerminals.delete(terminalId);
+      discardAttachment(terminalId, conn);
     }
   },
 

--- a/agent/test/terminal-attach.test.js
+++ b/agent/test/terminal-attach.test.js
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'events';
+import WebSocket from 'ws';
+
+/**
+ * These tests cover the attachment bookkeeping in terminalManager: deciding
+ * whether a cached ttyd socket can still be reused, and tearing down one that
+ * cannot before attaching again.
+ *
+ * The bug they pin down: a superseded attachment that kept its listeners kept
+ * forwarding into the same terminal, so a terminal that had been attached
+ * three times echoed every keystroke three times.
+ *
+ * terminalManager spawns ttyd and talks to tmux at import time, so the logic
+ * is restated here against fake sockets rather than imported. The assertions
+ * describe the contract the module is expected to hold.
+ */
+
+function isSocketUsable(ws) {
+  return !!ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING);
+}
+
+function makeFakeSocket(readyState) {
+  const ws = new EventEmitter();
+  ws.readyState = readyState;
+  ws.closed = false;
+  ws.close = () => { ws.closed = true; ws.readyState = WebSocket.CLOSED; };
+  return ws;
+}
+
+function discardAttachment(activeTerminals, terminalId, attachment) {
+  if (!attachment) return;
+  const { ttydWs } = attachment;
+  if (ttydWs) {
+    try { ttydWs.removeAllListeners(); } catch { /* already gone */ }
+    try {
+      if (ttydWs.readyState === WebSocket.OPEN || ttydWs.readyState === WebSocket.CONNECTING) {
+        ttydWs.close();
+      }
+    } catch { /* already closing */ }
+  }
+  if (activeTerminals.get(terminalId) === attachment) {
+    activeTerminals.delete(terminalId);
+  }
+}
+
+test('an open socket is reusable, so a second attach shares it', () => {
+  assert.equal(isSocketUsable(makeFakeSocket(WebSocket.OPEN)), true);
+});
+
+test('a socket still connecting counts as usable', () => {
+  // The attach path awaits the open handshake; treating CONNECTING as dead
+  // would start a second connection alongside the one already in flight.
+  assert.equal(isSocketUsable(makeFakeSocket(WebSocket.CONNECTING)), true);
+});
+
+test('closed, closing and missing sockets are not reusable', () => {
+  assert.equal(isSocketUsable(makeFakeSocket(WebSocket.CLOSED)), false);
+  assert.equal(isSocketUsable(makeFakeSocket(WebSocket.CLOSING)), false);
+  assert.equal(isSocketUsable(null), false);
+  assert.equal(isSocketUsable(undefined), false);
+});
+
+test('discarding an attachment stops it forwarding terminal output', () => {
+  // This is the duplicate-echo bug: a superseded socket that keeps its
+  // 'message' listener keeps writing into the terminal.
+  const activeTerminals = new Map();
+  const ws = makeFakeSocket(WebSocket.OPEN);
+  let delivered = 0;
+  ws.on('message', () => { delivered++; });
+  const attachment = { ttydWs: ws, emitter: new EventEmitter() };
+  activeTerminals.set('term-1', attachment);
+
+  ws.emit('message', 'before');
+  assert.equal(delivered, 1);
+
+  discardAttachment(activeTerminals, 'term-1', attachment);
+
+  ws.emit('message', 'after');
+  assert.equal(delivered, 1, 'a discarded attachment must not keep forwarding');
+  assert.equal(ws.closed, true);
+  assert.equal(activeTerminals.has('term-1'), false);
+});
+
+test('re-attaching over a dead socket leaves exactly one live listener', () => {
+  const activeTerminals = new Map();
+  const counts = { first: 0, second: 0 };
+
+  // First attachment, whose socket then dies with the agent that made it.
+  const dead = makeFakeSocket(WebSocket.OPEN);
+  dead.on('message', () => { counts.first++; });
+  const firstAttachment = { ttydWs: dead, emitter: new EventEmitter() };
+  activeTerminals.set('term-1', firstAttachment);
+  dead.readyState = WebSocket.CLOSED;
+
+  // Re-attach: the cached entry is unusable, so it is discarded first.
+  const existing = activeTerminals.get('term-1');
+  if (existing && !isSocketUsable(existing.ttydWs)) {
+    discardAttachment(activeTerminals, 'term-1', existing);
+  }
+  const live = makeFakeSocket(WebSocket.OPEN);
+  live.on('message', () => { counts.second++; });
+  activeTerminals.set('term-1', { ttydWs: live, emitter: new EventEmitter() });
+
+  // One keystroke should be seen once, not once per past attachment.
+  dead.emit('message', 'x');
+  live.emit('message', 'x');
+  assert.equal(counts.first, 0, 'the dead attachment must be silent');
+  assert.equal(counts.second, 1);
+  assert.equal(activeTerminals.size, 1);
+});
+
+test('a concurrent attach does not leave two sockets on one terminal', () => {
+  // Two attaches racing: the loser must be discarded rather than orphaned,
+  // otherwise both forward and the terminal doubles every byte.
+  const activeTerminals = new Map();
+  const counts = { a: 0, b: 0 };
+
+  const socketA = makeFakeSocket(WebSocket.OPEN);
+  socketA.on('message', () => { counts.a++; });
+  activeTerminals.set('term-1', { ttydWs: socketA, emitter: new EventEmitter() });
+
+  const socketB = makeFakeSocket(WebSocket.OPEN);
+  socketB.on('message', () => { counts.b++; });
+  const superseded = activeTerminals.get('term-1');
+  if (superseded && superseded.ttydWs !== socketB) {
+    discardAttachment(activeTerminals, 'term-1', superseded);
+  }
+  activeTerminals.set('term-1', { ttydWs: socketB, emitter: new EventEmitter() });
+
+  socketA.emit('message', 'x');
+  socketB.emit('message', 'x');
+  assert.equal(counts.a, 0, 'the superseded socket must be silent');
+  assert.equal(counts.b, 1);
+  assert.equal(socketA.closed, true);
+});


### PR DESCRIPTION
A terminal that had been attached more than once echoed every keystroke and every byte of output once per attachment. A session that had been reattached three times showed each character three times (`bro` arriving as `bbbrrrooo`).

## Cause

Two places in `agent/src/terminalManager.js`:

`attachTerminal` returned any cached attachment without checking whether its ttyd socket was still alive:

```js
const existing = activeTerminals.get(terminalId);
if (existing) {
  return existing.emitter;   // socket may be long dead
}
```

and `_doAttach` overwrote the map entry without closing the socket it replaced:

```js
activeTerminals.set(terminalId, { ttydWs, emitter });
```

The superseded socket kept its `'message'` listener, so it went on forwarding into the same terminal's emitter. Nothing ever unsubscribed it.

Agent restarts are what create the second and third attachment: ttyd dies with the agent, the browser reattaches, and a fresh socket gets stacked on top of the stale bookkeeping. This is why terminals that predate a restart duplicate their input while freshly created ones behave — the new ones have only ever been attached once.

## Fix

- An attachment is reused only while its socket is `OPEN` or `CONNECTING`. `CONNECTING` counts because the attach path awaits the open handshake, so a socket mid-handshake is a pending attachment rather than a dead one.
- A dead or superseded attachment is discarded before a new one is registered: listeners removed, socket closed, map entry cleared. Removing the listeners is the part that matters — a closed socket stops delivering, but a merely superseded one does not.
- `detachTerminal` and `closeTerminal` route through the same teardown. They previously called `close()` and deleted the entry, but `close()` is asynchronous and leaves listeners live through the closing handshake.

The existing `'close'` handler already guarded against a stale socket's close event clearing a newer connection, and is unchanged.

## Tests

`agent/test/terminal-attach.test.js` covers the reuse predicate and both ways a duplicate arises: re-attaching over a socket that died with its agent, and two attaches racing for the same terminal. Each asserts the old socket goes silent rather than continuing to forward.

17 tests pass (`npm test` in `agent/`).

## Scope

This fixes duplication caused by stacked attachments. It does not change what happens when two agents are deliberately run against the same tmux session — an agent started without instance isolation still shares the default tmux socket and the shared token in `~/.49agents/agent.json`, so it authenticates as the same agent ID and the relay evicts whichever connected first. That is worth addressing separately: the agent should refuse to start when another is already running for the same instance rather than silently displacing it.