### PR TITLE
Refuse a second agent for an instance instead of silently displacing the first

### DIFF
--- a/agent/bin/49-agent.js
+++ b/agent/bin/49-agent.js
@@ -75,8 +75,64 @@ async function handleLogin() {
   }
 }
 
+/**
+ * The PID of a live agent already serving this instance, or null.
+ *
+ * Two agents on one instance share a token, so they authenticate as the same
+ * agent and the relay closes whichever connected first — the running agent
+ * disappears with no indication of why. They also drive the same tmux
+ * sessions. Checking the PID file first turns that into a refusal to start.
+ *
+ * A PID file left behind by a crash is not a running agent, so a stale entry
+ * is cleared rather than treated as a conflict.
+ */
+function findRunningAgent() {
+  if (!existsSync(PID_FILE)) return null;
+
+  let pid;
+  try {
+    pid = parseInt(readFileSync(PID_FILE, 'utf-8').trim(), 10);
+  } catch {
+    return null;
+  }
+  if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) return null;
+
+  try {
+    process.kill(pid, 0); // signal 0 tests for existence without delivering
+    return pid;
+  } catch {
+    // No such process: the file outlived the agent that wrote it.
+    try { unlinkSync(PID_FILE); } catch { /* already gone */ }
+    return null;
+  }
+}
+
+function refuseDuplicateStart(pid) {
+  console.error(`[49-agent] An agent is already running for this instance (PID: ${pid}).`);
+  console.error(`[49-agent]   Instance:  ${config.instanceKey}`);
+  console.error(`[49-agent]   Cloud URL: ${config.cloudUrl}`);
+  console.error('');
+  console.error('  Starting a second agent here would disconnect the first one and');
+  console.error('  drive the same terminals. Either stop it:');
+  console.error('');
+  console.error('    49-agent stop');
+  console.error('');
+  console.error('  or point this agent at a different server, which gives it its own');
+  console.error('  config directory, terminal ports and tmux server:');
+  console.error('');
+  console.error('    TC_CLOUD_URL=ws://localhost:<other-port> 49-agent start');
+  console.error('');
+  process.exit(1);
+}
+
 async function handleStart() {
   const isDaemon = args.includes('--daemon') || args.includes('-d');
+  const force = args.includes('--force');
+
+  const running = findRunningAgent();
+  if (running && !force) {
+    refuseDuplicateStart(running);
+  }
 
   if (isDaemon) {
     // Fork to background

--- a/agent/src/index.js
+++ b/agent/src/index.js
@@ -165,7 +165,14 @@ export async function startAgent(options = {}) {
 
   relayClient.on('authFailed', (payload) => {
     console.error('[Agent] Authentication failed:', payload?.reason);
-    console.error('[Agent] Please re-run "49-agent login" to get a new token.');
+    if (payload?.code === 'duplicate_agent') {
+      // The token is fine — another agent already holds this machine's slot,
+      // so telling the user to log in again would send them the wrong way.
+      console.error('[Agent] Stop the other agent with "49-agent stop", or set');
+      console.error('[Agent] TC_CLOUD_URL to a different server to run alongside it.');
+    } else {
+      console.error('[Agent] Please re-run "49-agent login" to get a new token.');
+    }
     stopStatePolling();
     stopMetricsPolling();
   });

--- a/agent/test/duplicate-agent.test.js
+++ b/agent/test/duplicate-agent.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Guard against a second agent starting for an instance that already has one.
+ *
+ * Two agents on one instance share a token, so they authenticate as the same
+ * agent and the relay drops whichever connected first; they also drive the
+ * same tmux sessions. The CLI checks the instance's PID file before starting.
+ *
+ * The check is restated here rather than imported, because importing the CLI
+ * runs it. These tests pin the behaviour the CLI is expected to have.
+ */
+function findRunningAgent(pidFile, selfPid = process.pid) {
+  if (!existsSync(pidFile)) return null;
+
+  let pid;
+  try {
+    pid = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
+  } catch {
+    return null;
+  }
+  if (!Number.isInteger(pid) || pid <= 0 || pid === selfPid) return null;
+
+  try {
+    process.kill(pid, 0);
+    return pid;
+  } catch {
+    try { rmSync(pidFile); } catch { /* already gone */ }
+    return null;
+  }
+}
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-guard-'));
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('no PID file means nothing is running', () => {
+  withTempDir((dir) => {
+    assert.equal(findRunningAgent(join(dir, 'agent.pid')), null);
+  });
+});
+
+test('a PID file naming a live process reports a conflict', () => {
+  withTempDir((dir) => {
+    const pidFile = join(dir, 'agent.pid');
+    // This test process is a convenient stand-in for a running agent, but it
+    // must not look like "ourselves" or the check would skip it.
+    writeFileSync(pidFile, String(process.pid));
+    assert.equal(findRunningAgent(pidFile, process.pid + 1), process.pid);
+  });
+});
+
+test('a PID file left by a crashed agent is cleared, not treated as a conflict', () => {
+  withTempDir((dir) => {
+    const pidFile = join(dir, 'agent.pid');
+    // 2^22 is above the default pid_max on Linux and macOS, so no live
+    // process can own it.
+    writeFileSync(pidFile, '4194304');
+    assert.equal(findRunningAgent(pidFile), null);
+    assert.equal(existsSync(pidFile), false, 'the stale file should be removed');
+  });
+});
+
+test('a PID file holding garbage does not block startup', () => {
+  withTempDir((dir) => {
+    const pidFile = join(dir, 'agent.pid');
+    for (const junk of ['', '   ', 'not-a-pid', '-1', '0']) {
+      writeFileSync(pidFile, junk);
+      assert.equal(findRunningAgent(pidFile), null, `should ignore ${JSON.stringify(junk)}`);
+    }
+  });
+});
+
+test('an agent does not mistake its own PID file for a conflict', () => {
+  withTempDir((dir) => {
+    const pidFile = join(dir, 'agent.pid');
+    writeFileSync(pidFile, String(process.pid));
+    assert.equal(findRunningAgent(pidFile, process.pid), null);
+  });
+});

--- a/cloud/src/ws/agentHandler.js
+++ b/cloud/src/ws/agentHandler.js
@@ -80,11 +80,33 @@ export function handleAgentConnection(ws, userAgents, userBrowsers, latestAgentV
             if (!userAgents.has(userId)) {
               userAgents.set(userId, new Map());
             }
-            // Close any existing connection for this agent (stale reconnect)
+            // An existing connection for this agent is either a reconnect
+            // whose old socket has not been cleaned up yet, or a genuine
+            // second agent started against the same instance.
+            //
+            // Replacing a live connection is what makes a running agent
+            // vanish: both processes drive the same terminals, and whichever
+            // authenticated first is silently dropped. So a connection that
+            // is still open wins, and the newcomer is turned away with an
+            // explanation. A socket that is closing or closed is a stale
+            // reconnect and gets replaced as before.
             const existingAgent = userAgents.get(userId).get(agentId);
             if (existingAgent && existingAgent.ws !== ws) {
-              existingAgent.ws._replaced = true;
-              existingAgent.ws.close();
+              const previous = existingAgent.ws;
+              if (previous.readyState === WebSocket.OPEN) {
+                console.warn(`[ws:agent] Rejected duplicate connection for ${agentId} (${msg.payload.hostname}) — an agent is already connected`);
+                ws.send(JSON.stringify({
+                  type: 'agent:auth:fail',
+                  payload: {
+                    reason: 'Another agent is already connected for this machine. Stop it first, or point this agent at a different server.',
+                    code: 'duplicate_agent',
+                  },
+                }));
+                ws.close();
+                return;
+              }
+              previous._replaced = true;
+              previous.close();
             }
             // Normalize OS name: Node's process.platform reports 'darwin' but UI expects 'macos'
             const agentOs = msg.payload.os === 'darwin' ? 'macos' : (msg.payload.os || 'unknown');
@@ -98,6 +120,7 @@ export function handleAgentConnection(ws, userAgents, userBrowsers, latestAgentV
               os: agentOs,
               version: msg.payload.version || null,
               createdAt,
+              missedPings: 0,
             });
 
             // Update last_seen in DB
@@ -165,8 +188,11 @@ export function handleAgentConnection(ws, userAgents, userBrowsers, latestAgentV
 
       // --- Authenticated message handling ---
 
-      // Handle agent:pong (heartbeat response) -- just update last_seen
+      // Handle agent:pong (heartbeat response) -- update last_seen and mark
+      // the connection live again, so the heartbeat does not terminate it.
       if (msg.type === 'agent:pong') {
+        const agentInfo = userAgents.get(userId)?.get(agentId);
+        if (agentInfo) agentInfo.missedPings = 0;
         updateLastSeen(agentId);
         return;
       }

--- a/cloud/src/ws/relay.js
+++ b/cloud/src/ws/relay.js
@@ -171,13 +171,29 @@ export function setupWebSocketRelay(server, options = {}) {
     }
   });
 
-  // Heartbeat: ping agents every 30s to detect dead connections
+  // Heartbeat: ping agents every 30s and drop the ones that stopped answering.
+  //
+  // Terminating unresponsive sockets matters because a connected agent now
+  // takes precedence over a newcomer claiming the same agent ID. A socket
+  // that is half-open — the machine slept, the network dropped — still reads
+  // as OPEN locally, so without this it would hold that claim forever and the
+  // agent could never reconnect.
   const heartbeatInterval = setInterval(() => {
     for (const [userId, agents] of userAgents) {
       for (const [agentId, agentInfo] of agents) {
-        if (agentInfo.ws.readyState === WebSocket.OPEN) {
-          agentInfo.ws.send(JSON.stringify({ type: 'agent:ping' }));
+        if (agentInfo.ws.readyState !== WebSocket.OPEN) continue;
+
+        // Two consecutive unanswered pings (about 60s) is taken as dead. The
+        // agent answers every ping, so one missed round trip is already
+        // unusual; two rules out a single slow moment.
+        if (agentInfo.missedPings >= 2) {
+          console.warn(`[ws:agent] Agent ${agentId} (${agentInfo.hostname}) stopped responding to pings — closing`);
+          agentInfo.ws.terminate();
+          continue;
         }
+
+        agentInfo.missedPings = (agentInfo.missedPings || 0) + 1;
+        agentInfo.ws.send(JSON.stringify({ type: 'agent:ping' }));
       }
     }
   }, 30000);


### PR DESCRIPTION
Starting an agent for an instance that already had one silently killed the running agent. Both read the same token, so both authenticated as the same agent ID, and the relay closed whichever connected first. From the user's side a working agent simply stopped, with nothing explaining why — and both agents drove the same tmux sessions in the meantime.

This is the collision left over from the instance-isolation work: separate instances no longer interfere, but nothing stopped two agents claiming the *same* instance.

## Guards

Either path can be reached on its own, so both are covered.

**CLI.** `49-agent start` checks the instance's PID file and refuses when it names a live process, printing the instance key, the cloud URL, and the two ways forward:

```
[49-agent] An agent is already running for this instance (PID: 72123).
[49-agent]   Instance:  localhost-2600
[49-agent]   Cloud URL: ws://localhost:2600

  Starting a second agent here would disconnect the first one and
  drive the same terminals. Either stop it:

    49-agent stop

  or point this agent at a different server, which gives it its own
  config directory, terminal ports and tmux server:

    TC_CLOUD_URL=ws://localhost:<other-port> 49-agent start
```

A PID file left behind by a crash names no live process, so it is cleared rather than treated as a conflict. `--force` skips the check.

**Relay.** A second connection claiming an agent ID whose socket is still `OPEN` is now rejected with a `duplicate_agent` reason, instead of replacing the connection that is already working. A socket that is `CLOSING` or `CLOSED` is still a stale reconnect and is replaced as before, so restarting an agent behaves exactly as it did. The agent prints advice matching that reason rather than suggesting a re-login, since the token was never the problem.

## Heartbeat

Rejecting on a live socket only works if dead sockets are actually noticed. The heartbeat pinged agents every 30s but never checked for a reply, so a half-open connection — a slept machine, a dropped network — read as `OPEN` indefinitely. Under the new rule that would have held the agent ID forever and locked the agent out, turning a transient glitch into a permanent failure.

Agents that miss two consecutive pings (~60s) are now terminated, and a `agent:pong` clears the counter.

## Verification

Against two agents on one instance:

- Second agent refused by the CLI, first agent kept running.
- With `--force` to reach the relay guard: the second was rejected (`Rejected duplicate connection for agent_dev_local_localhost-2600`), exited cleanly with the right advice, and the first agent survived — where previously it would have been evicted.
- Killing the first agent and restarting it reconnected normally, confirming the guard does not block legitimate restarts.

22 tests pass (`npm test` in `agent/`), including new coverage of the PID check: live process, stale file, malformed contents, and an agent seeing its own PID.