### PR TITLE
Fix pane layout persistence and the three canvas preferences

### DIFF
--- a/cloud/package.json
+++ b/cloud/package.json
@@ -7,7 +7,8 @@
     "prestart": "node build.js",
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
-    "build": "node build.js"
+    "build": "node build.js",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "arctic": "^2.2.2",

--- a/cloud/src/auth/agentAuth.js
+++ b/cloud/src/auth/agentAuth.js
@@ -9,7 +9,9 @@
 import { jwtVerify, SignJWT } from 'jose';
 import { config } from '../config.js';
 import { upsertUser, getUserById } from '../db/users.js';
+import { upsertDevAgent } from '../db/agents.js';
 import { getLocalAuth } from './localAuth.js';
+import { hostname as osHostname } from 'os';
 
 const hasOAuth = !!(config.github.clientId || config.google.clientId);
 const isProduction = config.nodeEnv === 'production';
@@ -42,6 +44,22 @@ function devAgentId(instanceKey) {
   return `agent_dev_local_${String(instanceKey).replace(/[^a-z0-9_-]/gi, '')}`;
 }
 
+/**
+ * Resolve the dev agent identity, recording it in the agents table.
+ *
+ * pane_layouts.agent_id references agents(id). Dev mode does not go through
+ * the pairing routes that populate that table, so without this every layout
+ * save fails the foreign key and no pane position is ever persisted.
+ *
+ * upsertDevAgent returns the id actually stored, which differs from the
+ * synthetic one when a real agent already holds this (user, hostname) pair.
+ * Returning that id keeps the reference valid in both cases.
+ */
+function resolveDevAgent(instanceKey, userId) {
+  const id = devAgentId(instanceKey);
+  return upsertDevAgent(id, userId, osHostname(), process.platform);
+}
+
 export async function verifyAgentToken(token, instanceKey) {
   // Dev mode: no OAuth configured AND not production — accept 'dev' token without verification
   if (devModeEnabled && token === 'dev') {
@@ -55,7 +73,7 @@ export async function verifyAgentToken(token, instanceKey) {
         avatarUrl: null,
       });
       return {
-        agentId: devAgentId(instanceKey),
+        agentId: resolveDevAgent(instanceKey, devUser.id),
         userId: devUser.id,
       };
     }
@@ -72,7 +90,7 @@ export async function verifyAgentToken(token, instanceKey) {
       avatarUrl: localAuth.avatarUrl,
     });
     return {
-      agentId: devAgentId(instanceKey),
+      agentId: resolveDevAgent(instanceKey, user.id),
       userId: user.id,
     };
   }

--- a/cloud/src/db/agents.js
+++ b/cloud/src/db/agents.js
@@ -79,3 +79,37 @@ export function deleteAgent(agentId) {
   const db = getDb();
   db.prepare('DELETE FROM agents WHERE id = ?').run(agentId);
 }
+
+/**
+ * Record the synthetic agent used in dev/local mode.
+ *
+ * Dev mode mints an agent ID without going through the pairing routes that
+ * normally insert into this table, so nothing references it. pane_layouts
+ * has a foreign key on agent_id, which means every layout save from such an
+ * instance fails and no pane position is ever persisted.
+ *
+ * The id is fixed by the caller rather than generated, so this cannot reuse
+ * registerAgent. UNIQUE(user_id, hostname) may already be taken by a real
+ * paired agent on the same machine; in that case the existing row is left
+ * alone and its id returned, so the caller references a row that exists
+ * either way.
+ */
+export function upsertDevAgent(id, userId, hostname, os) {
+  const db = getDb();
+
+  const existing = db.prepare('SELECT id FROM agents WHERE id = ?').get(id);
+  if (existing) {
+    db.prepare("UPDATE agents SET last_seen_at = datetime('now') WHERE id = ?").run(id);
+    return id;
+  }
+
+  const byHostname = db.prepare('SELECT id FROM agents WHERE user_id = ? AND hostname = ?').get(userId, hostname);
+  if (byHostname) return byHostname.id;
+
+  db.prepare(`
+    INSERT INTO agents (id, user_id, hostname, os, token_hash, last_seen_at)
+    VALUES (?, ?, ?, ?, 'dev', datetime('now'))
+  `).run(id, userId, hostname, os || null);
+
+  return id;
+}

--- a/cloud/src/db/index.js
+++ b/cloud/src/db/index.js
@@ -186,6 +186,20 @@ export function initDatabase() {
     console.log('[db] Migration: Added projects column to user_preferences');
   } catch (e) { /* already exists */ }
 
+  // Migration: canvas preferences that were only ever held client-side
+  try {
+    db.prepare("ALTER TABLE user_preferences ADD COLUMN focus_mode TEXT NOT NULL DEFAULT 'hover'").run();
+    console.log('[db] Migration: Added focus_mode column to user_preferences');
+  } catch (e) { /* already exists */ }
+  try {
+    db.prepare('ALTER TABLE user_preferences ADD COLUMN teleport_animation INTEGER NOT NULL DEFAULT 1').run();
+    console.log('[db] Migration: Added teleport_animation column to user_preferences');
+  } catch (e) { /* already exists */ }
+  try {
+    db.prepare("ALTER TABLE user_preferences ADD COLUMN projects_sidebar_position TEXT NOT NULL DEFAULT 'right'").run();
+    console.log('[db] Migration: Added projects_sidebar_position column to user_preferences');
+  } catch (e) { /* already exists */ }
+
   // Migration: notifications tables
   try {
     db.prepare('SELECT id FROM notifications LIMIT 1').get();

--- a/cloud/src/db/preferences.js
+++ b/cloud/src/db/preferences.js
@@ -11,6 +11,9 @@ const DEFAULTS = {
   hud_state: '{}',
   tutorials_completed: '{}',
   projects: '[]',
+  focus_mode: 'hover',
+  teleport_animation: 1,
+  projects_sidebar_position: 'right',
 };
 
 export function getPreferences(userId) {
@@ -22,8 +25,8 @@ export function getPreferences(userId) {
 export function savePreferences(userId, prefs) {
   const db = getDb();
   db.prepare(`
-    INSERT INTO user_preferences (user_id, night_mode, terminal_theme, notification_sound, auto_remove_done, canvas_bg, snooze_duration, terminal_font, hud_state, tutorials_completed, projects, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    INSERT INTO user_preferences (user_id, night_mode, terminal_theme, notification_sound, auto_remove_done, canvas_bg, snooze_duration, terminal_font, hud_state, tutorials_completed, projects, focus_mode, teleport_animation, projects_sidebar_position, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
     ON CONFLICT(user_id) DO UPDATE SET
       night_mode = excluded.night_mode,
       terminal_theme = excluded.terminal_theme,
@@ -35,6 +38,9 @@ export function savePreferences(userId, prefs) {
       hud_state = excluded.hud_state,
       tutorials_completed = excluded.tutorials_completed,
       projects = excluded.projects,
+      focus_mode = excluded.focus_mode,
+      teleport_animation = excluded.teleport_animation,
+      projects_sidebar_position = excluded.projects_sidebar_position,
       updated_at = datetime('now')
   `).run(
     userId,
@@ -47,6 +53,9 @@ export function savePreferences(userId, prefs) {
     prefs.terminalFont || 'JetBrains Mono',
     prefs.hudState ? JSON.stringify(prefs.hudState) : '{}',
     prefs.tutorialsCompleted ? JSON.stringify(prefs.tutorialsCompleted) : '{}',
-    prefs.projects ? JSON.stringify(prefs.projects) : '[]'
+    prefs.projects ? JSON.stringify(prefs.projects) : '[]',
+    prefs.focusMode || 'hover',
+    prefs.teleportAnimation === false ? 0 : 1,
+    prefs.projectsSidebarPosition || 'right'
   );
 }

--- a/cloud/src/db/schema.sql
+++ b/cloud/src/db/schema.sql
@@ -75,6 +75,9 @@ CREATE TABLE IF NOT EXISTS user_preferences (
   hud_state          TEXT NOT NULL DEFAULT '{}',
   tutorials_completed TEXT NOT NULL DEFAULT '{}',
   projects           TEXT NOT NULL DEFAULT '[]',
+  focus_mode         TEXT NOT NULL DEFAULT 'hover',
+  teleport_animation INTEGER NOT NULL DEFAULT 1,
+  projects_sidebar_position TEXT NOT NULL DEFAULT 'right',
   updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/cloud/src/routes/preferences.js
+++ b/cloud/src/routes/preferences.js
@@ -16,6 +16,9 @@ export function setupPreferencesRoutes(app) {
       hudState:           prefs.hud_state ? JSON.parse(prefs.hud_state) : {},
       tutorialsCompleted: prefs.tutorials_completed ? JSON.parse(prefs.tutorials_completed) : {},
       projects:           prefs.projects ? JSON.parse(prefs.projects) : [],
+      focusMode:          prefs.focus_mode || 'hover',
+      teleportAnimation:  prefs.teleport_animation === undefined ? true : !!prefs.teleport_animation,
+      projectsSidebarPosition: prefs.projects_sidebar_position || 'right',
     });
   });
 
@@ -23,12 +26,12 @@ export function setupPreferencesRoutes(app) {
     const {
       nightMode, terminalTheme, notificationSound, autoRemoveDone,
       canvasBg, snoozeDuration, terminalFont, hudState, tutorialsCompleted,
-      projects,
+      projects, focusMode, teleportAnimation, projectsSidebarPosition,
     } = req.body;
     savePreferences(req.user.id, {
       nightMode, terminalTheme, notificationSound, autoRemoveDone,
       canvasBg, snoozeDuration, terminalFont, hudState, tutorialsCompleted,
-      projects,
+      projects, focusMode, teleportAnimation, projectsSidebarPosition,
     });
     res.json({ ok: true });
   });

--- a/cloud/test/layout-persistence.test.js
+++ b/cloud/test/layout-persistence.test.js
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const schema = readFileSync(join(here, '..', 'src', 'db', 'schema.sql'), 'utf-8');
+
+/**
+ * pane_layouts.agent_id references agents(id). Dev mode mints a synthetic
+ * agent ID without going through the pairing routes that populate that
+ * table, so before this fix every layout save from a local instance failed
+ * the foreign key and no pane position was ever persisted — which also took
+ * tab groups with it, since they ride in the layout metadata.
+ *
+ * These tests pin the constraint rather than the fix, so they still describe
+ * the requirement if the registration moves elsewhere.
+ */
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'layout-persist-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.pragma('foreign_keys = ON');
+  db.exec(schema);
+  db.prepare("INSERT INTO users (id, email, display_name) VALUES ('u1', 'a@b.com', 'A')").run();
+  return { db, dir };
+}
+
+function withDb(fn) {
+  const { db, dir } = freshDb();
+  try {
+    fn(db);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('a layout referencing an unregistered agent is rejected', () => {
+  withDb((db) => {
+    assert.throws(
+      () => db.prepare('INSERT INTO pane_layouts (id, user_id, agent_id, pane_type) VALUES (?, ?, ?, ?)')
+        .run('p1', 'u1', 'agent_dev_local_localhost-2800', 'terminal'),
+      /FOREIGN KEY/,
+    );
+  });
+});
+
+test('a layout saves once its agent is registered', () => {
+  withDb((db) => {
+    db.prepare("INSERT INTO agents (id, user_id, hostname, token_hash) VALUES ('agent_dev_local', 'u1', 'host', 'dev')").run();
+    db.prepare('INSERT INTO pane_layouts (id, user_id, agent_id, pane_type) VALUES (?, ?, ?, ?)')
+      .run('p1', 'u1', 'agent_dev_local', 'terminal');
+    assert.equal(db.prepare('SELECT COUNT(*) c FROM pane_layouts').get().c, 1);
+  });
+});
+
+test('tab group membership survives a layout round trip', () => {
+  withDb((db) => {
+    db.prepare("INSERT INTO agents (id, user_id, hostname, token_hash) VALUES ('agent_dev_local', 'u1', 'host', 'dev')").run();
+    const metadata = JSON.stringify({ tabGroupId: 'tg-1', tabGroupActive: true });
+    db.prepare('INSERT INTO pane_layouts (id, user_id, agent_id, pane_type, metadata) VALUES (?, ?, ?, ?, ?)')
+      .run('p1', 'u1', 'agent_dev_local', 'terminal', metadata);
+
+    const row = db.prepare('SELECT metadata FROM pane_layouts WHERE id = ?').get('p1');
+    const parsed = JSON.parse(row.metadata);
+    assert.equal(parsed.tabGroupId, 'tg-1');
+    assert.equal(parsed.tabGroupActive, true);
+  });
+});
+
+test('the canvas preferences have columns and sane defaults', () => {
+  withDb((db) => {
+    db.prepare('INSERT INTO user_preferences (user_id) VALUES (?)').run('u1');
+    const row = db.prepare('SELECT * FROM user_preferences WHERE user_id = ?').get('u1');
+
+    // Sent by the client on every save; before this fix they had nowhere to go.
+    assert.equal(row.focus_mode, 'hover');
+    assert.equal(row.teleport_animation, 1);
+    assert.equal(row.projects_sidebar_position, 'right');
+  });
+});
+
+test('the canvas preferences persist non-default values', () => {
+  withDb((db) => {
+    db.prepare(`INSERT INTO user_preferences (user_id, focus_mode, teleport_animation, projects_sidebar_position)
+                VALUES (?, ?, ?, ?)`).run('u1', 'click', 0, 'left');
+    const row = db.prepare('SELECT * FROM user_preferences WHERE user_id = ?').get('u1');
+    assert.equal(row.focus_mode, 'click');
+    assert.equal(row.teleport_animation, 0);
+    assert.equal(row.projects_sidebar_position, 'left');
+  });
+});


### PR DESCRIPTION
Two bugs, one of which was masking the other.

## Layouts never saved on a local instance

`pane_layouts.agent_id` references `agents(id)`, but dev/local mode mints
a synthetic agent ID (`agent_dev_local_<instance>`) without going through
the pairing routes that insert into that table. Every layout save from
such an instance failed the foreign key, so no pane position was ever
persisted.

```
FOREIGN KEY constraint failed
    at upsertPaneLayout (cloud/src/db/layouts.js:108)
```

`verifyAgentToken` now records the dev agent when it hands out that ID.
`upsertDevAgent` takes the id from the caller rather than generating one,
and yields to an existing row when a real paired agent already holds the
same `(user_id, hostname)` — so the reference is valid either way.

**Tab groups were collateral damage.** `tabGroupId` and `tabGroupActive`
ride in the layout `metadata` JSON; the client already sends them and the
restore path in `pane-creation.js` is fully implemented. They simply
never reached the database. No new columns were needed — fixing the
foreign key fixed tab group persistence for free.

## Three preferences had nowhere to go

`focusMode`, `teleportAnimation` and `projectsSidebarPosition` are sent
by `getAllPrefs()` on every save and read back by the client on load, but
had no columns and were dropped by both `savePreferences` and the
`/api/preferences` route. Added with migrations for existing databases.

## Verification

Fresh instance on its own port:
- dev agent now appears in `agents`; zero FK errors and zero layout-save
  500s in server and browser logs
- three layout rows persisted, carrying `tabGroupId` / `tabGroupActive`
- after reload the tab bar returns with both tabs and the correct active
  tab
- all three preferences round trip and apply on load — the projects
  sidebar came back on the left from a saved `'left'`

Against a copy of a real database with existing data:
- the three migrations apply cleanly
- all 7 existing layouts and 21 agents survive
- existing preferences intact

Five tests in `cloud/test/layout-persistence.test.js` pin the constraint
rather than the implementation, so they still describe the requirement if
the registration moves elsewhere. `cloud` had no `test` script; added one.

Server-side only — no client rebuild.